### PR TITLE
Use `serde` custom serialization to handle `SequencesSketch`

### DIFF
--- a/src/contain.rs
+++ b/src/contain.rs
@@ -559,10 +559,9 @@ fn get_seq_sketch(
             &read_sketch_file
         ));
         let read_reader = BufReader::with_capacity(10_000_000, file);
-        let read_sketch_enc: SequencesSketchEncode = bincode::deserialize_from(read_reader).expect(
+        let read_sketch: SequencesSketch = bincode::deserialize_from(read_reader).expect(
             &format!("The sketch `{}` is not a valid sketch. Perhaps it is an older incompatible version ", read_sketch_file),
         );
-        let read_sketch = SequencesSketch::from_enc(read_sketch_enc);
         if read_sketch.c > genome_c {
             error!("{} value of -c is {}; this is greater than the smallest value of -c = {} for a genome sketch. Exiting.", read_file, read_sketch.c, genome_c);
             return None;

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -357,8 +357,7 @@ pub fn sketch(args: SketchArgs) {
                         .expect(&format!("{} path not valid; exiting ", file_path_str)),
                 );
 
-                let enc = SequencesSketchEncode::new(read_sketch);
-                bincode::serialize_into(&mut read_sk_file, &enc).unwrap();
+                bincode::serialize_into(&mut read_sk_file, &read_sketch).unwrap();
                 info!("Sketching {} complete.", file_path_str);
             }
         });
@@ -409,8 +408,7 @@ pub fn sketch(args: SketchArgs) {
                     .expect(&format!("{} path not valid; exiting.", file_path_str)),
             );
 
-            let enc = SequencesSketchEncode::new(read_sketch);
-            bincode::serialize_into(&mut read_sk_file, &enc).unwrap();
+            bincode::serialize_into(&mut read_sk_file, &read_sketch).unwrap();
             info!("Sketching {} complete.", file_path_str);
         }
     });


### PR DESCRIPTION
Hi Jim!

As discussed this is a small PR that uses the capabilities of `serde` for custom serialization instead of manually having to create a dedicated extra struct and doing the conversion manually. The `serde` field attributes are documented here: https://serde.rs/field-attrs.html

