### PR TITLE
Add -r option (list of single-end fastq files) to profile

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -119,10 +119,13 @@ pub struct ContainArgs {
     #[clap(short='R', long="redundancy-threshold", help_heading = "ALGORITHM", help = "Removes redundant genomes up to a rough ANI percentile when profiling", default_value_t = 99.0, hidden=true)]
     pub redundant_ani: f64,
 
-    #[clap(short='1', long="first-pairs", multiple=true, help = "First pairs for raw paired-end reads (fastx/gzip)",help_heading = "SKETCHING")]
+    #[clap(short='r',long="reads", multiple=true, help = "Single-end raw reads (fastx/gzip)", display_order = 1, help_heading = "SKETCHING")]
+    pub reads: Vec<String>,
+
+    #[clap(short='1', long="first-pairs", multiple=true, help = "First pairs for raw paired-end reads (fastx/gzip)", help_heading = "SKETCHING")]
     pub first_pair: Vec<String>,
 
-    #[clap(short='2', long="second-pairs", multiple=true, help = "Second pairs for raw paired-end reads (fastx/gzip)",help_heading = "SKETCHING")]
+    #[clap(short='2', long="second-pairs", multiple=true, help = "Second pairs for raw paired-end reads (fastx/gzip)", help_heading = "SKETCHING")]
     pub second_pair: Vec<String>,
 
     #[clap(short, default_value_t = 200, help_heading = "SKETCHING", help = "Subsampling rate. Does nothing for pre-sketched files")]

--- a/src/contain.rs
+++ b/src/contain.rs
@@ -208,6 +208,10 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
         read_files.push(vec![first,second]);
     }
 
+    for read in args.reads.iter() {
+        read_files.push(vec![read]);
+    }
+
     if genome_sketch_files.is_empty() && genome_files.is_empty(){
         log::error!("No genome files found; see sylph query/profile -h for help. Exiting");
         std::process::exit(1);


### PR DESCRIPTION
Hi @bluenote-1577,

I’ve added an option to handle single-end FASTQ files in sylph profile.

It is already possible to do this with the following command:
`sylph profile db.syldb  file.fastq.gz `

However, since file format detection relies on the file extension, it does not work when the input is a file descriptor, for example, when multiple FASTQ files are concatenated on the fly:
```
sylph profile db.syldb  <(zcat file.fastq.gz file2.fastq.gz)  -o test
2025-02-25T15:05:54.876Z INFO  [sylph::contain] Obtaining sketches...
2025-02-25T15:05:54.876Z WARN  [sylph::contain] /dev/fd/63 file extension is not a sketch or a fasta/fastq file.
2025-02-25T15:05:54.876Z ERROR [sylph::contain] No read files found; see sylph query/profile -h for help. Exiting
```

While waiting for #35 to be implemented, this seems like a good alternative to me.

What do you think?

