### PR TITLE
docs: Add conda-forge channel to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ sylph uses a k-mer containment method. sylph's novelty lies in **using a statist
 #### Profile metagenome sample against [GTDB-R220](https://gtdb.ecogenomic.org/) (113,104 bacterial/archaeal species representative genomes) 
 
 ```sh
-conda install -c bioconda sylph
+conda install -c conda-forge -c bioconda sylph
 
 # download GTDB-R220 pre-built database (~13 GB)
 wget http://faust.compbio.cs.cmu.edu/sylph-stuff/gtdb-r220-c200-dbv1.syldb
@@ -61,7 +61,7 @@ sylph profile gtdb-r220-c200-dbv1.syldb *.fastq -t (threads) > profiling.tsv
 [![Anaconda-Server Badge](https://anaconda.org/bioconda/sylph/badges/latest_release_date.svg)](https://anaconda.org/bioconda/sylph)
 
 ```sh
-conda install -c bioconda sylph
+conda install -c conda-forge -c bioconda sylph
 ```
 
 #### Option 2: Build from source


### PR DESCRIPTION
I found I needed the `conda-forge` channel for dependency `libgcc-ng` - quick PR to add to docs, if helpful.