### PR TITLE
Two-stage profiling: db-convert + profile --two-stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "boomphf"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617e2d952880a00583ddb9237ac3965732e8df6a92a8e7bcc054100ec467ec3b"
+dependencies = [
+ "crossbeam-utils",
+ "log",
+ "rayon",
+ "serde",
+ "wyhash",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1124,7 @@ version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "bincode",
+ "boomphf",
  "clap",
  "fastrand",
  "flate2",
@@ -1456,6 +1470,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wyhash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf6e163c25e3fac820b4b453185ea2dea3b6a3e0a721d4d23d75bd33734c295"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ smallvec = { version = "1", features = ["union","serde","write"] }
 serde = { version = "1", features = ["derive"] }
 bincode = "1"
 fxhash = "0"
+boomphf = { version = "0.6", features = ["serde"] }
 clap = { version = "3", features = ["derive"] }
 flate2 = { version = "1.0.17", features = ["zlib-ng"], default-features = false }
 statrs="0.16"

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -171,6 +171,8 @@ pub struct ContainArgs {
     pub screen_c: Option<usize>,
     #[clap(long="screen-ani", default_value_t = SCREEN_MIN_ANI_DEFAULT, help_heading = "TWO-STAGE PROFILING", help = "Minimum adjusted ANI (0-100) for a genome to pass the first-stage screen. Deliberately permissive; the dense stage recovers specificity.")]
     pub screen_ani: f64,
+    #[clap(long="screen-min-matches", default_value_t = 1, help_heading = "TWO-STAGE PROFILING", help = "Minimum number of matched stage-1 screen k-mers for a genome to pass the screen and be densely decoded. Default 1 keeps the same results as single-stage; raising it (e.g. with a permissive --screen-ani) cheaply prunes genomes that pass on a handful of chance-shared k-mers, cutting wasted dense decodes at a small sensitivity cost for very-low-coverage genomes.")]
+    pub screen_min_matches: usize,
     #[clap(long="dense-cache", help_heading = "TWO-STAGE PROFILING", help = "Directory of cached per-genome dense sketches (*.sylgn). Genomes (re)sketched for the dense stage are stored here and reused across samples/runs, so a dense database is grown lazily only for genomes that actually appear.")]
     pub dense_cache: Option<String>,
     #[clap(long="screen-dump", hidden=true, help_heading = "TWO-STAGE PROFILING", help = "Debug: write a TSV of every stage-1 screen survivor (genome, matched/total screen k-mers, naive/adjusted ANI, median coverage) to this file.")]

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -22,6 +22,25 @@ pub enum Mode {
     ///Inspect sketched .syldb and .sylsp files.
     #[clap(arg_required_else_help = true, display_order = 4)]
     Inspect(InspectArgs),
+    ///Convert a standard database (.syldb) into a two-stage seekable database (.syl2db) for `profile --two-stage`.
+    #[clap(arg_required_else_help = true, display_order = 5)]
+    DbConvert(DbConvertArgs),
+}
+
+#[derive(Args)]
+pub struct DbConvertArgs {
+    #[clap(multiple=true, help = "Standard genome database sketches (*.syldb) to convert")]
+    pub files: Vec<String>,
+    #[clap(short='o', long="output", help = "Output two-stage database name (.syl2db appended)")]
+    pub output: String,
+    #[clap(long="screen-c", default_value_t = SCREEN_C_DEFAULT, help = "Subsampling rate -c of the small in-memory stage-1 SCREEN index (the bincoded sparse hashes). Must be >= the database -c. A coarser (larger) value gives a smaller/faster screen index. The dense per-genome blocks always keep every k-mer at the database -c.")]
+    pub screen_c: usize,
+    #[clap(short, default_value_t = 3, help = "Number of threads")]
+    pub threads: usize,
+    #[clap(long="trace", help = "Trace output")]
+    pub trace: bool,
+    #[clap(long="debug", help = "Debug output")]
+    pub debug: bool,
 }
 
 
@@ -82,7 +101,7 @@ pub struct SketchArgs {
     pub second_pair: Vec<String>,
 }
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub struct ContainArgs {
     #[clap(multiple=true, help = "Pre-sketched *.syldb/*.sylsp files. Raw single-end fastq/fasta are allowed and will be automatically sketched to .sylsp/.syldb")]
     pub files: Vec<String>,
@@ -143,6 +162,19 @@ pub struct ContainArgs {
     pub out_file_name: Option<String>,
     #[clap(long="log-reassignments", help = "Output information for how k-mers for genomes are reassigned during `profile`. Caution: can be verbose and slows down computation.")]
     pub log_reassignments: bool,
+
+    #[clap(long="two-stage", help_heading = "TWO-STAGE PROFILING", help = "Two-stage profiling (profile only): cheaply SCREEN the sample against the (sparse) database, then densely profile ONLY the genomes that pass the screen. Lets a sparse pre-built database (e.g. -c 200 GTDB) deliver dense -c profiling without ever building/loading a dense full database.")]
+    pub two_stage: bool,
+    #[clap(long="dense-c", default_value_t = DENSE_C_DEFAULT, help_heading = "TWO-STAGE PROFILING", help = "Subsampling rate -c for the dense second stage. Genomes passing the screen are (re)sketched at this rate from their source fasta if the database is sparser than this. The sample sketch must have -c <= this value.")]
+    pub dense_c: usize,
+    #[clap(long="screen-c", help_heading = "TWO-STAGE PROFILING", help = "Subsampling rate -c for the cheap first-stage screen. Default: the database's own -c. Must be >= the database -c (a sketch can only be made sparser, never denser).")]
+    pub screen_c: Option<usize>,
+    #[clap(long="screen-ani", default_value_t = SCREEN_MIN_ANI_DEFAULT, help_heading = "TWO-STAGE PROFILING", help = "Minimum adjusted ANI (0-100) for a genome to pass the first-stage screen. Deliberately permissive; the dense stage recovers specificity.")]
+    pub screen_ani: f64,
+    #[clap(long="dense-cache", help_heading = "TWO-STAGE PROFILING", help = "Directory of cached per-genome dense sketches (*.sylgn). Genomes (re)sketched for the dense stage are stored here and reused across samples/runs, so a dense database is grown lazily only for genomes that actually appear.")]
+    pub dense_cache: Option<String>,
+    #[clap(long="screen-dump", hidden=true, help_heading = "TWO-STAGE PROFILING", help = "Debug: write a TSV of every stage-1 screen survivor (genome, matched/total screen k-mers, naive/adjusted ANI, median coverage) to this file.")]
+    pub screen_dump: Option<String>,
 
 
     //Hidden options that are embedded in the args but no longer used... 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -15,3 +15,10 @@ pub const MAX_DEDUP_COUNT: u32 = 4;
 pub const MAX_DEDUP_LEN: usize = 10000000;
 pub const DEFAULT_FPR: f64 = 0.0001;
 pub const MED_KMER_FOR_ID_EST: f64 = 3.;
+pub const DENSE_C_DEFAULT: usize = 50;
+pub const SCREEN_C_DEFAULT: usize = 3000;
+pub const SCREEN_MIN_ANI_DEFAULT: f64 = 85.;
+pub const GENOME_SKETCH_SUFFIX: &str = ".sylgn";
+/// Two-stage seekable database: a small bincoded sparse (screen) index plus
+/// per-genome Golomb-Rice compressed dense blocks loaded on demand.
+pub const TWO_STAGE_DB_SUFFIX: &str = ".syl2db";

--- a/src/contain.rs
+++ b/src/contain.rs
@@ -217,6 +217,33 @@ fn compute_dense_survivors(
     screen_args.pseudotax = false;
     screen_args.minimum_ani = Some(args.screen_ani);
     screen_args.no_ci = true;
+    // The screen scores against sketches sub-sampled to `screen_c`, so the dense
+    // `-M/--min-number-kmers` floor would over-reject here: a genome/contig has
+    // only ~length/screen_c sparse k-mers, so the dense floor M corresponds to a
+    // length of M*screen_c (e.g. 50*3000 = 150 kb), silently dropping smaller
+    // genomes (viruses, plasmids, short contigs) that single-stage profiling
+    // would report. Scale the floor to the screen resolution so a genome that
+    // could clear the dense floor also clears the screen; genomes truly below the
+    // floor are still rejected at the dense stage.
+    screen_args.min_number_kmers = args.min_number_kmers * dense_c as f64 / screen_c as f64;
+
+    // The densify fallback (no .syl2db) re-sketches whole FASTA files keyed by
+    // file name, which collapses `--individual-records` databases (many records
+    // share a file name) into a single whole-file sketch. Reject that up front;
+    // `db-convert` to a .syl2db preserves individual records and works fine.
+    if two_stage_db.is_none() {
+        let mut seen = std::collections::HashSet::with_capacity(genome_sketches.len());
+        for gs in genome_sketches.iter() {
+            if !seen.insert(gs.file_name.as_str()) {
+                log::error!(
+                    "--two-stage on a raw --individual-records database is unsupported \
+                     (densification re-sketches whole files). Convert it with `sylph db-convert` \
+                     first (a .syl2db preserves individual records). Exiting."
+                );
+                std::process::exit(1);
+            }
+        }
+    }
 
     let survivors: Mutex<Vec<usize>> = Mutex::new(vec![]);
     // Optional per-survivor dump: (genome, matched k-mers, total screen k-mers,

--- a/src/contain.rs
+++ b/src/contain.rs
@@ -7,6 +7,7 @@ use fxhash::FxHashMap;
 use crate::constants::*;
 use crate::inference::*;
 use crate::sketch::*;
+use crate::twostage_db::TwoStageDb;
 use crate::types::*;
 use log::*;
 use rayon::prelude::*;
@@ -112,6 +113,182 @@ fn get_chunks(indices: &Vec<usize>, steps: usize) -> Vec<Vec<usize>>{
     return_chunks
 }
 
+/// FracMinHash keeps a hashed k-mer iff `hash < u64::MAX / c`. Because the
+/// threshold shrinks as `c` grows, the set of k-mers kept at a large `c` (sparse)
+/// is a strict subset of the set kept at a small `c` (dense). So we can turn an
+/// already-loaded sketch into a *sparser* one for free by dropping every k-mer
+/// whose hash is above the coarser threshold. We can NOT go the other way --
+/// making a sketch denser requires re-reading the source sequence.
+fn subsample_view(gs: &GenomeSketch, target_c: usize) -> GenomeSketch {
+    let mut out = gs.clone();
+    if target_c <= gs.c {
+        // Already at (or denser than) the requested rate; nothing to drop.
+        return out;
+    }
+    let thresh = u64::MAX / (target_c as u64);
+    out.c = target_c;
+    out.genome_kmers = gs.genome_kmers.iter().copied().filter(|h| *h < thresh).collect();
+    if let Some(p) = &gs.pseudotax_tracked_nonused_kmers {
+        out.pseudotax_tracked_nonused_kmers =
+            Some(p.iter().copied().filter(|h| *h < thresh).collect());
+    }
+    out
+}
+
+/// Path of the per-genome dense-sketch cache file for a given source fasta.
+fn dense_cache_path(dir: &str, file_name: &str, dense_c: usize, k: usize) -> String {
+    let h = fxhash::hash64(&file_name);
+    format!("{}/{:016x}.c{}.k{}{}", dir, h, dense_c, k, GENOME_SKETCH_SUFFIX)
+}
+
+/// Obtain a *dense* (`-c = dense_c`) sketch for a genome that passed the screen.
+///   * database already as dense / denser -> reuse (subsampling if denser),
+///   * database sparser -> (re)sketch the source fasta at `dense_c`,
+///     reusing an on-disk cache and an in-memory cache so each fasta is only
+///     ever sketched once. This is how a dense database is grown lazily, only
+///     for the genomes that actually appear in samples.
+fn densify_genome(
+    db_sketch: &GenomeSketch,
+    dense_c: usize,
+    k: usize,
+    min_spacing: usize,
+    mem_cache: &Mutex<FxHashMap<String, GenomeSketch>>,
+    disk_cache: &Option<String>,
+) -> Option<GenomeSketch> {
+    if db_sketch.c <= dense_c {
+        return Some(subsample_view(db_sketch, dense_c));
+    }
+
+    let key = db_sketch.file_name.clone();
+    if let Some(hit) = mem_cache.lock().unwrap().get(&key) {
+        return Some(hit.clone());
+    }
+
+    if let Some(dir) = disk_cache {
+        let path = dense_cache_path(dir, &key, dense_c, k);
+        if Path::new(&path).exists() {
+            if let Ok(file) = File::open(&path) {
+                let reader = BufReader::with_capacity(10_000_000, file);
+                if let Ok(gs) = bincode::deserialize_from::<_, GenomeSketch>(reader) {
+                    mem_cache.lock().unwrap().insert(key, gs.clone());
+                    return Some(gs);
+                }
+            }
+        }
+    }
+
+    let sketched = sketch_genome(dense_c, k, &key, min_spacing, true)?;
+
+    if let Some(dir) = disk_cache {
+        let path = dense_cache_path(dir, &key, dense_c, k);
+        match File::create(&path) {
+            Ok(file) => {
+                let mut writer = BufWriter::new(file);
+                if let Err(e) = bincode::serialize_into(&mut writer, &sketched) {
+                    warn!("Could not write dense-sketch cache {}: {}", path, e);
+                }
+            }
+            Err(e) => warn!("Could not create dense-sketch cache {}: {}", path, e),
+        }
+    }
+
+    mem_cache.lock().unwrap().insert(key, sketched.clone());
+    Some(sketched)
+}
+
+/// Two-stage stage 1 + 2: screen `sequence_sketch` against all `genome_sketches`
+/// at the sparse `screen_c`, then return *dense* (`dense_c`) sketches for only
+/// the genomes that pass. The returned set replaces the full database for the
+/// (expensive) dense profiling that follows.
+fn compute_dense_survivors(
+    args: &ContainArgs,
+    genome_sketches: &Vec<GenomeSketch>,
+    sequence_sketch: &SequencesSketch,
+    screen_c: usize,
+    dense_c: usize,
+    k: usize,
+    min_spacing: usize,
+    mem_cache: &Mutex<FxHashMap<String, GenomeSketch>>,
+    disk_cache: &Option<String>,
+    two_stage_db: Option<&TwoStageDb>,
+) -> Vec<GenomeSketch> {
+    // Stage 1: cheap, permissive screen (query-like settings, no CIs).
+    let mut screen_args = args.clone();
+    screen_args.pseudotax = false;
+    screen_args.minimum_ani = Some(args.screen_ani);
+    screen_args.no_ci = true;
+
+    let survivors: Mutex<Vec<usize>> = Mutex::new(vec![]);
+    // Optional per-survivor dump: (genome, matched k-mers, total screen k-mers,
+    // naive ANI, adjusted ANI, median coverage).
+    let dump: Mutex<Vec<(String, usize, usize, f64, f64, f64)>> = Mutex::new(vec![]);
+    (0..genome_sketches.len()).into_par_iter().for_each(|i| {
+        let sv = subsample_view(&genome_sketches[i], screen_c);
+        if let Some(res) = get_stats(&screen_args, &sv, sequence_sketch, None, false) {
+            if args.screen_dump.is_some() {
+                dump.lock().unwrap().push((
+                    res.gn_name.to_string(),
+                    res.containment_index.0,
+                    res.containment_index.1,
+                    res.naive_ani * 100.,
+                    res.final_est_ani * 100.,
+                    res.median_cov,
+                ));
+            }
+            survivors.lock().unwrap().push(i);
+        }
+    });
+    let mut survivors = survivors.into_inner().unwrap();
+    survivors.sort_unstable();
+    log::info!(
+        "{}: stage-1 screen (c={}, min-ANI {}) kept {} / {} candidate genomes",
+        sequence_sketch.file_name, screen_c, args.screen_ani, survivors.len(), genome_sketches.len()
+    );
+    if let Some(path) = &args.screen_dump {
+        let mut f = BufWriter::new(File::create(path).expect("could not create --screen-dump file"));
+        writeln!(f, "Genome_file\tscreen_matched_kmers\tscreen_total_kmers\tnaive_ani\tscreen_adjusted_ani\tscreen_median_cov").unwrap();
+        for (g, m, t, na, ea, mc) in dump.into_inner().unwrap() {
+            writeln!(f, "{}\t{}\t{}\t{:.3}\t{:.3}\t{}", g, m, t, na, ea, mc).unwrap();
+        }
+        log::info!("Wrote stage-1 screen dump to {}", path);
+    }
+
+    // Stage 2. With a .syl2db we decode each survivor's dense block into a
+    // short-lived sketch, run the (prefetch-friendly) pass-1 profiling on it, and
+    // keep it only if it passes -- so the discarded majority is freed immediately
+    // and never cached, keeping peak RAM proportional to the genomes that survive
+    // rather than to the (much larger) screen-survivor set. With a plain database
+    // the dense sketch is derived/re-sketched by densify_genome and filtered the
+    // same way.
+    let dense: Mutex<Vec<GenomeSketch>> = Mutex::new(vec![]);
+    survivors.par_iter().for_each(|i| {
+        let g = match two_stage_db {
+            Some(db) => match db.decode_dense(*i as u32) {
+                Ok(g) => Some(g),
+                Err(e) => {
+                    warn!("Could not decode dense block for genome index {}: {}", i, e);
+                    None
+                }
+            },
+            None => {
+                densify_genome(&genome_sketches[*i], dense_c, k, min_spacing, mem_cache, disk_cache)
+            }
+        };
+        if let Some(g) = g {
+            // Keep only genomes that pass pass-1 profiling; drop (free) the rest.
+            if get_stats(args, &g, sequence_sketch, None, false).is_some() {
+                dense.lock().unwrap().push(g);
+            }
+        }
+    });
+    let dense = dense.into_inner().unwrap();
+    log::info!(
+        "{}: stage-2 dense profiling (c={}) against {} genomes",
+        sequence_sketch.file_name, dense_c, dense.len()
+    );
+    dense
+}
+
 pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
 
     if pseudotax_in{
@@ -154,6 +331,7 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
     log::info!("Obtaining sketches...");
     let mut genome_sketch_files = vec![];
     let mut genome_files = vec![];
+    let mut two_stage_db_files = vec![];
     let mut read_sketch_files = vec![];
     let mut read_files = vec![];
 
@@ -187,7 +365,9 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
             }
         }
 
-        if genome_sketch_good_suffix{
+        if file.ends_with(TWO_STAGE_DB_SUFFIX){
+            two_stage_db_files.push(file);
+        } else if genome_sketch_good_suffix{
             genome_sketch_files.push(file);
         } else if sample_sketch_good_suffix{
             read_sketch_files.push(file);
@@ -217,7 +397,7 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
         read_files.push(vec![read]);
     }
 
-    if genome_sketch_files.is_empty() && genome_files.is_empty(){
+    if genome_sketch_files.is_empty() && genome_files.is_empty() && two_stage_db_files.is_empty(){
         log::error!("No genome files found; see sylph query/profile -h for help. Exiting");
         std::process::exit(1);
     }
@@ -227,8 +407,31 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
         std::process::exit(1);
     }
 
-    let genome_sketches = get_genome_sketches(&args, &genome_sketch_files, &genome_files);
-    let genome_index_vec = (0..genome_sketches.len()).collect::<Vec<usize>>();
+    // A .syl2db is a self-contained two-stage database: open it (loading only the
+    // sparse stage-1 index) and use its per-genome sparse sketches as the screen.
+    let two_stage_db: Option<TwoStageDb> = if !two_stage_db_files.is_empty() {
+        if two_stage_db_files.len() > 1 || !genome_sketch_files.is_empty() || !genome_files.is_empty() {
+            log::error!("A two-stage database ({}) must be the only genome input. Exiting", TWO_STAGE_DB_SUFFIX);
+            std::process::exit(1);
+        }
+        if !args.pseudotax {
+            log::error!("Two-stage databases ({}) are only supported for `sylph profile`, not `sylph query`. Exiting", TWO_STAGE_DB_SUFFIX);
+            std::process::exit(1);
+        }
+        log::info!("Opening two-stage database {} (loading stage-1 sparse index)...", two_stage_db_files[0]);
+        let db = crate::twostage_db::open_file(two_stage_db_files[0])
+            .unwrap_or_else(|e| panic!("{} is not a valid two-stage database: {}", two_stage_db_files[0], e));
+        // The database is inherently two-stage; enable the screen-then-densify path.
+        args.two_stage = true;
+        Some(db)
+    } else {
+        None
+    };
+
+    let genome_sketches = match &two_stage_db {
+        Some(db) => db.screen_sketches.clone(),
+        None => get_genome_sketches(&args, &genome_sketch_files, &genome_files),
+    };
     log::info!("Finished obtaining genome sketches.");
 
     if genome_sketches.is_empty() {
@@ -240,6 +443,54 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
         log::error!("Attempting profiling, but *.syldb was sketched with the --disable-profiling option. Exiting");
         std::process::exit(1);
     }
+
+    // ---- Two-stage profiling setup ----------------------------------------
+    // A .syl2db dictates its own dense rate (`c`) and stage-1 screen rate
+    // (`screen_c`); otherwise they come from the database `-c` and the flags.
+    let (db_c, db_k, screen_c, dense_c) = match &two_stage_db {
+        Some(db) => (db.c, db.k, db.screen_c, db.c),
+        None => {
+            let db_c = genome_sketches[0].c;
+            (
+                db_c,
+                genome_sketches[0].k,
+                args.screen_c.unwrap_or(SCREEN_C_DEFAULT).max(db_c),
+                args.dense_c,
+            )
+        }
+    };
+    let dense_mem_cache: Mutex<FxHashMap<String, GenomeSketch>> = Mutex::new(FxHashMap::default());
+    if args.two_stage {
+        if !args.pseudotax {
+            log::error!("--two-stage is only supported for `sylph profile`, not `sylph query`. Exiting");
+            std::process::exit(1);
+        }
+        if dense_c > screen_c {
+            log::error!("--dense-c ({}) must be <= the screen -c ({}); the dense stage cannot be sparser than the screen. Exiting", dense_c, screen_c);
+            std::process::exit(1);
+        }
+        if let Some(dir) = &args.dense_cache {
+            if let Err(e) = std::fs::create_dir_all(dir) {
+                log::error!("Could not create --dense-cache directory {}: {}. Exiting", dir, e);
+                std::process::exit(1);
+            }
+        }
+        if two_stage_db.is_some() {
+            log::info!(
+                "Two-stage database profiling: screen at c={} (min-ANI {}), dense profile at c={} by decoding only the screened genomes' compressed blocks.",
+                screen_c, args.screen_ani, dense_c
+            );
+        } else {
+            log::info!(
+                "Two-stage profiling enabled: screen at c={} (min-ANI {}), dense profile at c={}{}.",
+                screen_c, args.screen_ani, dense_c,
+                if db_c > dense_c { " by (re)sketching candidate genomes from their source fasta" } else { "" }
+            );
+        }
+    }
+    // The sample sketch must not be sparser than the genome rate it is compared
+    // against: the full DB rate normally, or the dense rate under two-stage.
+    let effective_genome_c = if args.two_stage { dense_c } else { db_c };
 
     let num_raw_read_files = read_files.len();
     let step;
@@ -271,11 +522,11 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
     chunks.into_iter().for_each(|chunk| {
         chunk.into_par_iter().for_each(|j|{
             let is_sketch = j >= read_files.len() - read_sketch_files.len();
-            let sequence_sketch = get_seq_sketch(&args, &read_files[j], is_sketch, genome_sketches[0].c, genome_sketches[0].k);
+            let sequence_sketch = get_seq_sketch(&args, &read_files[j], is_sketch, effective_genome_c, genome_sketches[0].k);
             if sequence_sketch.is_some(){
                 let first_read_file = read_files[j][0];
                 let sequence_sketch = sequence_sketch.unwrap();
-                
+
                 let kmer_id_opt;
                 if args.seq_id.is_some(){
                     kmer_id_opt = Some((args.seq_id.unwrap()/100.).powf(sequence_sketch.k as f64));
@@ -284,10 +535,25 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
                     kmer_id_opt = get_kmer_identity(&sequence_sketch, args.estimate_unknown);
                     log::debug!("{} has estimated identity {:.3}.", &first_read_file, kmer_id_opt.unwrap().powf(1./sequence_sketch.k as f64) * 100.);
                 }
-                
+
+                // Under two-stage, screen first and replace the full database
+                // with dense sketches of only the genomes that pass.
+                let dense_local: Vec<GenomeSketch>;
+                let active_sketches: &Vec<GenomeSketch> = if args.two_stage {
+                    dense_local = compute_dense_survivors(
+                        &args, &genome_sketches, &sequence_sketch, screen_c, dense_c,
+                        db_k, args.min_spacing_kmer, &dense_mem_cache, &args.dense_cache,
+                        two_stage_db.as_ref(),
+                    );
+                    &dense_local
+                } else {
+                    &genome_sketches
+                };
+                let active_index_vec = (0..active_sketches.len()).collect::<Vec<usize>>();
+
                 let stats_vec_seq: Mutex<Vec<AniResult>> = Mutex::new(vec![]);
-                genome_index_vec.par_iter().for_each(|i| {
-                    let genome_sketch = &genome_sketches[*i];
+                active_index_vec.par_iter().for_each(|i| {
+                    let genome_sketch = &active_sketches[*i];
                     let res = get_stats(&args, &genome_sketch, &sequence_sketch, None, args.log_reassignments);
                     if res.is_some() {
                         //res.as_mut().unwrap().genome_sketch_index = *i;
@@ -663,20 +929,84 @@ fn get_stats<'a>(
         }
     }
 
+    let n_kmers = gn_kmers.len();
+    let reassign_log = if winner_map.is_some() && log_reassign {
+        Some((
+            genome_sketch.file_name.as_str(),
+            genome_sketch.first_contig_name.as_str(),
+            kmers_lost_count,
+        ))
+    } else {
+        None
+    };
+    let fin = finalize_stats(args, genome_sketch.k, n_kmers, contain_count, covs, reassign_log)?;
+
+    let seq_name = if let Some(sample) = &sequence_sketch.sample_name {
+        sample.clone()
+    } else {
+        sequence_sketch.file_name.clone()
+    };
+    let kmers_lost = if winner_map.is_some() {
+        Some(kmers_lost_count)
+    } else {
+        None
+    };
+
+    Some(AniResult {
+        naive_ani: fin.naive_ani,
+        final_est_ani: fin.final_est_ani,
+        final_est_cov: fin.final_est_cov,
+        seq_name,
+        gn_name: genome_sketch.file_name.as_str(),
+        contig_name: genome_sketch.first_contig_name.as_str(),
+        mean_cov: fin.mean_cov,
+        median_cov: fin.median_cov,
+        containment_index: (contain_count, n_kmers),
+        lambda: fin.lambda,
+        ani_ci: fin.ani_ci,
+        lambda_ci: fin.lambda_ci,
+        genome_sketch,
+        rel_abund: None,
+        seq_abund: None,
+        kmers_lost,
+    })
+}
+
+/// Scalar outputs of the coverage-correction + ANI estimation.
+struct Finalized {
+    naive_ani: f64,
+    final_est_ani: f64,
+    final_est_cov: f64,
+    median_cov: f64,
+    mean_cov: f64,
+    lambda: AdjustStatus,
+    ani_ci: (Option<f64>, Option<f64>),
+    lambda_ci: (Option<f64>, Option<f64>),
+}
+
+/// Coverage-correction + ANI math shared by `get_stats` (materialized genome)
+/// and the streaming two-stage pass-1 (which never builds a genome `Vec`).
+/// Consumes the matched coverage counts `covs` and the genome k-mer count
+/// `n_kmers`; applies the minimum-ANI gate (returns None below it). When
+/// `reassign_log` is set, logs a drop during pseudotax reassignment.
+fn finalize_stats(
+    args: &ContainArgs,
+    k: usize,
+    n_kmers: usize,
+    contain_count: usize,
+    mut covs: Vec<u32>,
+    reassign_log: Option<(&str, &str, usize)>,
+) -> Option<Finalized> {
     if covs.is_empty() {
         return None;
     }
-    let naive_ani = f64::powf(
-        contain_count as f64 / gn_kmers.len() as f64,
-        1. / genome_sketch.k as f64,
-    );
+    let naive_ani = f64::powf(contain_count as f64 / n_kmers as f64, 1. / k as f64);
     covs.sort();
-    //let covs = &covs[0..covs.len() * 99 / 100];
     let median_cov = covs[covs.len() / 2] as f64;
     let pois = Poisson::new(median_cov).unwrap();
     let mut max_cov = f64::MAX;
-    if median_cov < 30.{
-        for i in covs.len() / 2..covs.len(){
+    if median_cov < 30. {
+        for i in covs.len() / 2..covs.len() {
             let cov = covs[i];
             if pois.cdf(cov.into()) < CUTOFF_PVALUE {
                 max_cov = cov as f64;
@@ -685,18 +1015,12 @@ fn get_stats<'a>(
             }
         }
     }
-    log::trace!("COV VECTOR for {}/{}: {:?}, MAX_COV_THRESHOLD: {}", sequence_sketch.file_name, genome_sketch.file_name ,covs, max_cov);
 
-
-    let mut full_covs = vec![0; gn_kmers.len() - contain_count];
+    let mut full_covs = vec![0; n_kmers - contain_count];
     for cov in covs.iter() {
         if (*cov as f64) <= max_cov {
             full_covs.push(*cov);
         }
-    }
-    let var = var(&full_covs);
-    if var.is_some(){
-        log::trace!("VAR {} {}", var.unwrap(), genome_sketch.file_name);
     }
     let mean_cov = full_covs.iter().sum::<u32>() as f64 / full_covs.len() as f64;
     let geq1_mean_cov = full_covs.iter().sum::<u32>() as f64 / covs.len() as f64;
@@ -713,7 +1037,7 @@ fn get_stats<'a>(
         } else if args.nb {
             test_lambda = binary_search_lambda(&full_covs)
         } else if args.mle {
-            test_lambda = mle_zip(&full_covs, sequence_sketch.k as f64)
+            test_lambda = mle_zip(&full_covs, k as f64)
         } else {
             test_lambda = ratio_lambda(&full_covs, args.min_count_correct)
         };
@@ -725,18 +1049,14 @@ fn get_stats<'a>(
     }
 
     let final_est_cov;
-
     if let AdjustStatus::Lambda(lam) = use_lambda {
         final_est_cov = lam
-    } else if median_cov < MAX_MEDIAN_FOR_MEAN_FINAL_EST{
+    } else if median_cov < MAX_MEDIAN_FOR_MEAN_FINAL_EST {
         final_est_cov = geq1_mean_cov;
-    } else{
-        if args.mean_coverage{
-            final_est_cov = geq1_mean_cov;
-        }
-        else{
-            final_est_cov = median_cov;
-        }
+    } else if args.mean_coverage {
+        final_est_cov = geq1_mean_cov;
+    } else {
+        final_est_cov = median_cov;
     }
 
     let opt_lambda;
@@ -746,8 +1066,8 @@ fn get_stats<'a>(
         opt_lambda = Some(final_est_cov)
     };
 
-    let opt_est_ani = ani_from_lambda(opt_lambda, mean_cov, sequence_sketch.k as f64, &full_covs);
-    
+    let opt_est_ani = ani_from_lambda(opt_lambda, mean_cov, k as f64, &full_covs);
+
     let final_est_ani;
     if opt_lambda.is_none() || opt_est_ani.is_none() || args.no_adj {
         final_est_ani = naive_ani;
@@ -755,74 +1075,42 @@ fn get_stats<'a>(
         final_est_ani = opt_est_ani.unwrap();
     }
 
-    let min_ani = if args.minimum_ani.is_some() {args.minimum_ani.unwrap()/100. }
-        else if args.pseudotax { MIN_ANI_P_DEF } 
-        else { MIN_ANI_DEF };
+    let min_ani = if args.minimum_ani.is_some() {
+        args.minimum_ani.unwrap() / 100.
+    } else if args.pseudotax {
+        MIN_ANI_P_DEF
+    } else {
+        MIN_ANI_DEF
+    };
     if final_est_ani < min_ani {
-        if winner_map.is_some(){
-            //Used to be > min ani, now it is not after reassignment
-            if log_reassign{
-                log::info!("Genome/contig {}/{} has ANI = {} < {} after reassigning {} k-mers ({} contained k-mers after reassign)", 
-                    genome_sketch.file_name,
-                    genome_sketch.first_contig_name,
-                    final_est_ani * 100.,
-                    min_ani * 100.,
-                    kmers_lost_count,
-                    contain_count)
-            }
-
+        if let Some((gn, ctg, lost)) = reassign_log {
+            log::info!(
+                "Genome/contig {}/{} has ANI = {} < {} after reassigning {} k-mers ({} contained k-mers after reassign)",
+                gn, ctg, final_est_ani * 100., min_ani * 100., lost, contain_count
+            );
         }
         return None;
     }
 
     let (mut low_ani, mut high_ani, mut low_lambda, mut high_lambda) = (None, None, None, None);
     if !args.no_ci && opt_lambda.is_some() {
-        let bootstrap = bootstrap_interval(&full_covs, sequence_sketch.k as f64, &args);
+        let bootstrap = bootstrap_interval(&full_covs, k as f64, args);
         low_ani = bootstrap.0;
         high_ani = bootstrap.1;
         low_lambda = bootstrap.2;
         high_lambda = bootstrap.3;
     }
 
-    
-    let seq_name;
-    if let Some(sample) = &sequence_sketch.sample_name{
-        seq_name = sample.clone();
-    }
-    else{
-        seq_name = sequence_sketch.file_name.clone();
-    }
-
-    let kmers_lost;
-    if winner_map.is_some(){
-        kmers_lost = Some(kmers_lost_count)
-    }
-    else{
-        kmers_lost = None;
-    }
-
-    let ani_result = AniResult {
+    Some(Finalized {
         naive_ani,
         final_est_ani,
         final_est_cov,
-        seq_name: seq_name,
-        gn_name: genome_sketch.file_name.as_str(),
-        contig_name: genome_sketch.first_contig_name.as_str(),
-        mean_cov: geq1_mean_cov,
         median_cov,
-        containment_index: (contain_count, gn_kmers.len()),
+        mean_cov: geq1_mean_cov,
         lambda: use_lambda,
         ani_ci: (low_ani, high_ani),
         lambda_ci: (low_lambda, high_lambda),
-        genome_sketch: genome_sketch,
-        rel_abund: None,
-        seq_abund: None,
-        kmers_lost: kmers_lost,
-
-    };
-    //log::trace!("Other time {:?}", Instant::now() - start_t_initial);
-
-    return Some(ani_result);
+    })
 }
 
 

--- a/src/contain.rs
+++ b/src/contain.rs
@@ -7,7 +7,7 @@ use fxhash::FxHashMap;
 use crate::constants::*;
 use crate::inference::*;
 use crate::sketch::*;
-use crate::twostage_db::TwoStageDb;
+use crate::twostage_db::{ScreenIndex, TwoStageDb};
 use crate::types::*;
 use log::*;
 use rayon::prelude::*;
@@ -196,13 +196,16 @@ fn densify_genome(
     Some(sketched)
 }
 
-/// Two-stage stage 1 + 2: screen `sequence_sketch` against all `genome_sketches`
-/// at the sparse `screen_c`, then return *dense* (`dense_c`) sketches for only
-/// the genomes that pass. The returned set replaces the full database for the
-/// (expensive) dense profiling that follows.
+/// Two-stage stage 1 + 2: screen `sequence_sketch` against the pooled
+/// `screen_index` (a single inverted pass over the sample at the sparse
+/// `screen_c`), then return *dense* (`dense_c`) sketches for only the genomes
+/// that pass. `plain_genome_sketches` is `Some` only for the non-`.syl2db`
+/// (densify) path; a `.syl2db` decodes survivors by index instead. The returned
+/// set replaces the full database for the (expensive) dense profiling that follows.
 fn compute_dense_survivors(
     args: &ContainArgs,
-    genome_sketches: &Vec<GenomeSketch>,
+    screen_index: &ScreenIndex,
+    plain_genome_sketches: Option<&Vec<GenomeSketch>>,
     sequence_sketch: &SequencesSketch,
     screen_c: usize,
     dense_c: usize,
@@ -231,7 +234,7 @@ fn compute_dense_survivors(
     // file name, which collapses `--individual-records` databases (many records
     // share a file name) into a single whole-file sketch. Reject that up front;
     // `db-convert` to a .syl2db preserves individual records and works fine.
-    if two_stage_db.is_none() {
+    if let Some(genome_sketches) = plain_genome_sketches {
         let mut seen = std::collections::HashSet::with_capacity(genome_sketches.len());
         for gs in genome_sketches.iter() {
             if !seen.insert(gs.file_name.as_str()) {
@@ -245,38 +248,60 @@ fn compute_dense_survivors(
         }
     }
 
-    let survivors: Mutex<Vec<usize>> = Mutex::new(vec![]);
+    // Stage 1 = "Path B": one inverted pass over the sample produces, per genome,
+    // the same matched-coverage multiset the per-genome `get_stats` loop would
+    // collect; feeding it to the same `finalize_stats` + `--screen-min-matches` +
+    // `min_number_kmers` checks reproduces the survivor set exactly, in O(sample)
+    // rather than O(reference) work. (See experiments/7_mphf_screen_again.)
+    let name_of = |g: usize| -> String {
+        match two_stage_db {
+            Some(db) => db.genome_file_name(g as u32).to_string(),
+            None => plain_genome_sketches.unwrap()[g].file_name.clone(),
+        }
+    };
+    let hits: Vec<(u32, Vec<u32>)> = screen_index
+        .gather_hits(sequence_sketch)
+        .into_iter()
+        .collect();
     // Optional per-survivor dump: (genome, matched k-mers, total screen k-mers,
     // naive ANI, adjusted ANI, median coverage).
     let dump: Mutex<Vec<(String, usize, usize, f64, f64, f64)>> = Mutex::new(vec![]);
-    (0..genome_sketches.len()).into_par_iter().for_each(|i| {
-        let sv = subsample_view(&genome_sketches[i], screen_c);
-        if let Some(res) = get_stats(&screen_args, &sv, sequence_sketch, None, false) {
+    let mut survivors: Vec<usize> = hits
+        .into_par_iter()
+        .filter_map(|(g, covs)| {
+            let g = g as usize;
+            let n_kmers = screen_index.sparse_count[g] as usize;
+            // Mirror get_stats: reject genomes below the (scaled) k-mer floor.
+            if (n_kmers as f64) < screen_args.min_number_kmers {
+                return None;
+            }
+            let contain_count = covs.len();
+            // finalize_stats applies the screen min-ANI gate (returns None below it).
+            let fin = finalize_stats(&screen_args, k, n_kmers, contain_count, covs, None)?;
             // Require at least `--screen-min-matches` matched screen k-mers; this
             // cheaply drops genomes that clear the (permissive) screen ANI on only
             // a few chance-shared k-mers, before they cost a dense decode. Default
             // 1 == current behaviour (get_stats already needs >= 1 match).
-            if res.containment_index.0 < args.screen_min_matches {
-                return;
+            if contain_count < args.screen_min_matches {
+                return None;
             }
             if args.screen_dump.is_some() {
                 dump.lock().unwrap().push((
-                    res.gn_name.to_string(),
-                    res.containment_index.0,
-                    res.containment_index.1,
-                    res.naive_ani * 100.,
-                    res.final_est_ani * 100.,
-                    res.median_cov,
+                    name_of(g),
+                    contain_count,
+                    n_kmers,
+                    fin.naive_ani * 100.,
+                    fin.final_est_ani * 100.,
+                    fin.median_cov,
                 ));
             }
-            survivors.lock().unwrap().push(i);
-        }
-    });
-    let mut survivors = survivors.into_inner().unwrap();
+            Some(g)
+        })
+        .collect();
     survivors.sort_unstable();
     log::info!(
         "{}: stage-1 screen (c={}, min-ANI {}) kept {} / {} candidate genomes",
-        sequence_sketch.file_name, screen_c, args.screen_ani, survivors.len(), genome_sketches.len()
+        sequence_sketch.file_name, screen_c, args.screen_ani, survivors.len(), screen_index.num_genomes()
     );
     if let Some(path) = &args.screen_dump {
         let mut f = BufWriter::new(File::create(path).expect("could not create --screen-dump file"));
@@ -305,7 +330,7 @@ fn compute_dense_survivors(
                 }
             },
             None => {
-                densify_genome(&genome_sketches[*i], dense_c, k, min_spacing, mem_cache, disk_cache)
+                densify_genome(&plain_genome_sketches.unwrap()[*i], dense_c, k, min_spacing, mem_cache, disk_cache)
             }
         };
         if let Some(g) = g {
@@ -462,20 +487,32 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
         None
     };
 
+    // A .syl2db screens via its pooled stage-1 index and decodes dense blocks by
+    // index for stage 2, so it carries no in-memory `GenomeSketch` list. Only the
+    // plain-database path materializes one here.
     let genome_sketches = match &two_stage_db {
-        Some(db) => db.screen_sketches.clone(),
+        Some(_) => Vec::new(),
         None => get_genome_sketches(&args, &genome_sketch_files, &genome_files),
     };
     log::info!("Finished obtaining genome sketches.");
 
-    if genome_sketches.is_empty() {
-        log::error!("No genome sketches found; see sylph query/profile -h for help. Exiting");
-        std::process::exit(1);
-    }
-
-    if genome_sketches.first().unwrap().pseudotax_tracked_nonused_kmers.is_none() && args.pseudotax{
-        log::error!("Attempting profiling, but *.syldb was sketched with the --disable-profiling option. Exiting");
-        std::process::exit(1);
+    match &two_stage_db {
+        Some(db) => {
+            if db.is_empty() {
+                log::error!("Two-stage database contains no genomes. Exiting");
+                std::process::exit(1);
+            }
+        }
+        None => {
+            if genome_sketches.is_empty() {
+                log::error!("No genome sketches found; see sylph query/profile -h for help. Exiting");
+                std::process::exit(1);
+            }
+            if genome_sketches.first().unwrap().pseudotax_tracked_nonused_kmers.is_none() && args.pseudotax{
+                log::error!("Attempting profiling, but *.syldb was sketched with the --disable-profiling option. Exiting");
+                std::process::exit(1);
+            }
+        }
     }
 
     // ---- Two-stage profiling setup ----------------------------------------
@@ -526,6 +563,20 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
     // against: the full DB rate normally, or the dense rate under two-stage.
     let effective_genome_c = if args.two_stage { dense_c } else { db_c };
 
+    // Stage-1 screen index. A .syl2db carries its own (loaded from file); the
+    // plain-database two-stage path builds one in memory once, from each genome
+    // subsampled to `screen_c`.
+    let inmem_screen_index: Option<ScreenIndex> = if args.two_stage && two_stage_db.is_none() {
+        log::info!("Building in-memory stage-1 screen index (c={}).", screen_c);
+        let sparse_per_genome: Vec<Vec<u64>> = genome_sketches
+            .par_iter()
+            .map(|gs| subsample_view(gs, screen_c).genome_kmers)
+            .collect();
+        Some(ScreenIndex::build(&sparse_per_genome, screen_c, db_k))
+    } else {
+        None
+    };
+
     let num_raw_read_files = read_files.len();
     let step;
     if let Some(sample_threads) = args.sample_threads{
@@ -556,7 +607,7 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
     chunks.into_iter().for_each(|chunk| {
         chunk.into_par_iter().for_each(|j|{
             let is_sketch = j >= read_files.len() - read_sketch_files.len();
-            let sequence_sketch = get_seq_sketch(&args, &read_files[j], is_sketch, effective_genome_c, genome_sketches[0].k);
+            let sequence_sketch = get_seq_sketch(&args, &read_files[j], is_sketch, effective_genome_c, db_k);
             if sequence_sketch.is_some(){
                 let first_read_file = read_files[j][0];
                 let sequence_sketch = sequence_sketch.unwrap();
@@ -574,8 +625,13 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
                 // with dense sketches of only the genomes that pass.
                 let dense_local: Vec<GenomeSketch>;
                 let active_sketches: &Vec<GenomeSketch> = if args.two_stage {
+                    let screen_index = match &two_stage_db {
+                        Some(db) => &db.screen_index,
+                        None => inmem_screen_index.as_ref().unwrap(),
+                    };
+                    let plain_genome_sketches = two_stage_db.is_none().then_some(&genome_sketches);
                     dense_local = compute_dense_survivors(
-                        &args, &genome_sketches, &sequence_sketch, screen_c, dense_c,
+                        &args, screen_index, plain_genome_sketches, &sequence_sketch, screen_c, dense_c,
                         db_k, args.min_spacing_kmer, &dense_mem_cache, &args.dense_cache,
                         two_stage_db.as_ref(),
                     );

--- a/src/contain.rs
+++ b/src/contain.rs
@@ -252,6 +252,13 @@ fn compute_dense_survivors(
     (0..genome_sketches.len()).into_par_iter().for_each(|i| {
         let sv = subsample_view(&genome_sketches[i], screen_c);
         if let Some(res) = get_stats(&screen_args, &sv, sequence_sketch, None, false) {
+            // Require at least `--screen-min-matches` matched screen k-mers; this
+            // cheaply drops genomes that clear the (permissive) screen ANI on only
+            // a few chance-shared k-mers, before they cost a dense decode. Default
+            // 1 == current behaviour (get_stats already needs >= 1 match).
+            if res.containment_index.0 < args.screen_min_matches {
+                return;
+            }
             if args.screen_dump.is_some() {
                 dump.lock().unwrap().push((
                     res.gn_name.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod types;
 pub mod seeding;
 pub mod cmdline;
 pub mod contain;
+pub mod twostage_db;
 pub mod inference;
 pub mod inspect;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use sylph::cmdline::*;
 use sylph::sketch;
 use sylph::contain;
+use sylph::twostage_db;
 use sylph::inspect;
 //use std::panic::set_hook;
 
@@ -27,5 +28,6 @@ fn main() {
         Mode::Query(contain_args) => contain::contain(contain_args, false),
         Mode::Profile(contain_args) => contain::contain(contain_args, true),
         Mode::Inspect(inspect_args) => inspect::inspect(inspect_args),
+        Mode::DbConvert(args) => twostage_db::run_db_convert(args),
     }
 }

--- a/src/twostage_db.rs
+++ b/src/twostage_db.rs
@@ -1,0 +1,759 @@
+//! Two-stage seekable genome database (`.syl2db`) for `profile --two-stage`.
+//!
+//! A standard sylph database (`.syldb`) is a single bincoded `Vec<GenomeSketch>`
+//! that must be loaded in full to profile a sample. For two-stage profiling we
+//! only ever need the *dense* k-mers of the handful of genomes a sample actually
+//! contains; loading every genome's dense k-mers up front is wasteful for a large
+//! reference. This module re-packs a `.syldb` into a two-stage seekable layout,
+//! mirroring (in spirit) the `.sylref` format of wwood/sylph#2 but deliberately
+//! simpler:
+//!
+//!   * **No k-mer dereplication.** Each genome keeps its *own complete* k-mer set;
+//!     a k-mer shared by several genomes is stored in each of them. We do not
+//!     assign each k-mer a single owner.
+//!   * **No shared/pooled hashes.** There is no conserved-k-mer pool.
+//!
+//! ## Layout
+//!
+//! ```text
+//! [4]  magic  "SY2D"
+//! [1]  version
+//! [8]  footer_offset (u64 LE)
+//! ---- body ----
+//! dense block 0, dense block 1, ...      (each: Golomb-Rice compressed)
+//! ---- footer ----
+//! bincode(Footer)                        (the sparse stage-1 index + metadata)
+//! ```
+//!
+//! **Stage 1 (sparse, bincoded, loaded fully).** The footer is a bincoded
+//! `Footer` holding, per genome, a FracMinHash subsample of its k-mers at a
+//! coarser rate `screen_c` (the same thresholding `subsample_view` uses, so the
+//! sparse set is a genuine sparser sketch). Querying a sample against these tiny
+//! sketches yields the genomes it contains.
+//!
+//! **Stage 2 (dense, Golomb-Rice, loaded on demand).** Each genome's *full*
+//! `genome_kmers` and `pseudotax_tracked_nonused_kmers` are an independently
+//! Golomb-Rice-coded block at a known offset. Only the genomes that pass the
+//! stage-1 screen are decoded (and cached across samples) to reconstruct their
+//! exact `GenomeSketch` for the dense profiling pass.
+
+use crate::cmdline::DbConvertArgs;
+use crate::constants::*;
+use crate::types::*;
+use fxhash::FxHashMap;
+use log::*;
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::os::unix::fs::FileExt;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+const MAGIC: &[u8; 4] = b"SY2D";
+/// Format version (dense blocks are Golomb-Rice coded).
+const VERSION: u8 = 1;
+/// magic (4) + version (1) + footer offset (8)
+const HEADER_LEN: u64 = 13;
+
+// --- primitive integer / bit coding -----------------------------------------
+
+fn write_uvarint(w: &mut Vec<u8>, mut x: u64) {
+    loop {
+        let mut byte = (x & 0x7f) as u8;
+        x >>= 7;
+        if x != 0 {
+            byte |= 0x80;
+        }
+        w.push(byte);
+        if x == 0 {
+            break;
+        }
+    }
+}
+
+fn read_uvarint<R: Read>(r: &mut R) -> io::Result<u64> {
+    let mut result: u64 = 0;
+    let mut shift: u32 = 0;
+    loop {
+        let mut b = [0u8; 1];
+        r.read_exact(&mut b)?;
+        result |= ((b[0] & 0x7f) as u64) << shift;
+        if b[0] & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "uvarint overflow",
+            ));
+        }
+    }
+    Ok(result)
+}
+
+/// LSB-first bit writer accumulating into a byte buffer.
+struct BitWriter {
+    buf: Vec<u8>,
+    cur: u8,
+    nbits: u8,
+}
+
+impl BitWriter {
+    fn new() -> Self {
+        BitWriter {
+            buf: Vec::new(),
+            cur: 0,
+            nbits: 0,
+        }
+    }
+    #[inline]
+    fn write_bit(&mut self, b: u32) {
+        if b != 0 {
+            self.cur |= 1 << self.nbits;
+        }
+        self.nbits += 1;
+        if self.nbits == 8 {
+            self.buf.push(self.cur);
+            self.cur = 0;
+            self.nbits = 0;
+        }
+    }
+    #[inline]
+    fn write_bits(&mut self, val: u64, n: u32) {
+        for i in 0..n {
+            self.write_bit(((val >> i) & 1) as u32);
+        }
+    }
+    #[inline]
+    fn write_unary(&mut self, q: u64) {
+        for _ in 0..q {
+            self.write_bit(1);
+        }
+        self.write_bit(0);
+    }
+    fn finish(mut self) -> Vec<u8> {
+        if self.nbits > 0 {
+            self.buf.push(self.cur);
+        }
+        self.buf
+    }
+}
+
+struct BitReader<'a> {
+    buf: &'a [u8],
+    byte: usize,
+    bit: u8,
+}
+
+impl<'a> BitReader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        BitReader {
+            buf,
+            byte: 0,
+            bit: 0,
+        }
+    }
+    #[inline]
+    fn read_bit(&mut self) -> io::Result<u32> {
+        if self.byte >= self.buf.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "bitstream truncated",
+            ));
+        }
+        let b = (self.buf[self.byte] >> self.bit) & 1;
+        self.bit += 1;
+        if self.bit == 8 {
+            self.bit = 0;
+            self.byte += 1;
+        }
+        Ok(b as u32)
+    }
+    #[inline]
+    fn read_bits(&mut self, n: u32) -> io::Result<u64> {
+        let mut v = 0u64;
+        for i in 0..n {
+            v |= (self.read_bit()? as u64) << i;
+        }
+        Ok(v)
+    }
+    #[inline]
+    fn read_unary(&mut self) -> io::Result<u64> {
+        let mut q = 0u64;
+        while self.read_bit()? == 1 {
+            q += 1;
+        }
+        Ok(q)
+    }
+}
+
+/// Sort + delta + Golomb-Rice encode a set of hashes onto `out`. Order is not
+/// preserved (hash sets are order-independent); duplicates become zero gaps and
+/// are preserved. The Rice parameter is chosen from the mean gap and written
+/// inline, so the block is self-delimiting given the leading count.
+fn write_hashes(out: &mut Vec<u8>, hashes: &[u64]) {
+    let mut sorted = hashes.to_vec();
+    sorted.sort_unstable();
+    write_uvarint(out, sorted.len() as u64);
+    if sorted.is_empty() {
+        return;
+    }
+    let mut deltas = Vec::with_capacity(sorted.len());
+    let mut prev = 0u64;
+    for &h in &sorted {
+        deltas.push(h - prev);
+        prev = h;
+    }
+    // Rice parameter k ~ log2(mean gap): near-optimal for the geometric gap
+    // distribution of uniformly random hashes.
+    let sum: u128 = deltas.iter().map(|&d| d as u128).sum();
+    let mean = (sum / deltas.len() as u128).max(1);
+    let mut k = 0u32;
+    while k < 63 && (1u128 << (k + 1)) <= mean {
+        k += 1;
+    }
+    out.push(k as u8);
+    let mut bw = BitWriter::new();
+    for &d in &deltas {
+        bw.write_unary(d >> k);
+        if k > 0 {
+            bw.write_bits(d & ((1u64 << k) - 1), k);
+        }
+    }
+    let bits = bw.finish();
+    write_uvarint(out, bits.len() as u64);
+    out.extend_from_slice(&bits);
+}
+
+fn read_hashes<R: Read>(r: &mut R) -> io::Result<Vec<u64>> {
+    let n = read_uvarint(r)? as usize;
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+    let mut kb = [0u8; 1];
+    r.read_exact(&mut kb)?;
+    let k = kb[0] as u32;
+    let blen = read_uvarint(r)? as usize;
+    let mut bits = vec![0u8; blen];
+    r.read_exact(&mut bits)?;
+    let mut br = BitReader::new(&bits);
+    let mut out = Vec::with_capacity(n);
+    let mut prev = 0u64;
+    for _ in 0..n {
+        let q = br.read_unary()?;
+        let low = if k > 0 { br.read_bits(k)? } else { 0 };
+        let d = (q << k) | low;
+        prev = prev.wrapping_add(d);
+        out.push(prev);
+    }
+    Ok(out)
+}
+
+// --- footer (stage-1 sparse index + metadata) -------------------------------
+
+/// Per-genome metadata plus the stage-1 sparse k-mer subsample. Everything here
+/// is loaded into memory when the database is opened; the dense block at
+/// `dense_offset` is decoded lazily.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+pub struct GenomeMeta {
+    pub file_name: String,
+    pub first_contig_name: String,
+    pub gn_size: usize,
+    pub min_spacing: usize,
+    pub has_pseudotax: bool,
+    pub dense_offset: u64,
+    /// FracMinHash subsample of `genome_kmers` at `screen_c` (stage-1 screen).
+    pub sparse_kmers: Vec<u64>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+pub struct Footer {
+    /// Dense rate: every k-mer is kept in the dense blocks at this `-c`.
+    pub c: usize,
+    pub k: usize,
+    /// Sparse stage-1 screen rate (`screen_c >= c`).
+    pub screen_c: usize,
+    pub genomes: Vec<GenomeMeta>,
+}
+
+// --- writing ----------------------------------------------------------------
+
+/// Re-pack genome sketches into the two-stage seekable layout and write to `w`.
+/// `screen_c` is the (coarser) stage-1 subsampling rate; it must be `>= c`.
+/// Dense blocks are Golomb-Rice coded.
+pub fn write_two_stage_db<W: Write>(
+    mut w: W,
+    sketches: &[GenomeSketch],
+    screen_c: usize,
+) -> io::Result<()> {
+    let c = sketches.first().map(|s| s.c).unwrap_or(0);
+    let k = sketches.first().map(|s| s.k).unwrap_or(0);
+    // FracMinHash threshold for the sparse subsample (same rule as subsample_view).
+    let thresh = if screen_c == 0 {
+        u64::MAX
+    } else {
+        u64::MAX / screen_c as u64
+    };
+
+    let mut body: Vec<u8> = Vec::new();
+    let mut genomes: Vec<GenomeMeta> = Vec::with_capacity(sketches.len());
+
+    for gs in sketches {
+        let dense_offset = HEADER_LEN + body.len() as u64;
+        write_hashes(&mut body, &gs.genome_kmers);
+        match &gs.pseudotax_tracked_nonused_kmers {
+            Some(p) => {
+                body.push(1);
+                write_hashes(&mut body, p);
+            }
+            None => body.push(0),
+        }
+        let sparse_kmers: Vec<u64> = gs
+            .genome_kmers
+            .iter()
+            .copied()
+            .filter(|&h| h < thresh)
+            .collect();
+        genomes.push(GenomeMeta {
+            file_name: gs.file_name.clone(),
+            first_contig_name: gs.first_contig_name.clone(),
+            gn_size: gs.gn_size,
+            min_spacing: gs.min_spacing,
+            has_pseudotax: gs.pseudotax_tracked_nonused_kmers.is_some(),
+            dense_offset,
+            sparse_kmers,
+        });
+    }
+
+    let footer = Footer {
+        c,
+        k,
+        screen_c,
+        genomes,
+    };
+    let footer_bytes = bincode::serialize(&footer).map_err(io::Error::other)?;
+    let footer_offset = HEADER_LEN + body.len() as u64;
+
+    w.write_all(MAGIC)?;
+    w.write_all(&[VERSION])?;
+    w.write_all(&footer_offset.to_le_bytes())?;
+    w.write_all(&body)?;
+    w.write_all(&footer_bytes)?;
+    Ok(())
+}
+
+// --- opened database --------------------------------------------------------
+
+/// Backing store for the dense blocks.
+///   * `File`  - positional `read_at` (pread) of just the requested block bytes.
+///     No shared cursor, so concurrent reads from any number of threads need no
+///     lock; only the touched block bytes (plus reclaimable OS page cache) cost
+///     memory, so RSS stays low. This is the path used for `.syl2db` files.
+///   * `Owned` - whole file in memory; for in-memory readers / tests.
+enum DenseData {
+    File(File),
+    Owned(Vec<u8>),
+}
+
+impl DenseData {
+    /// Whole-file bytes; only valid for the in-memory backing (used to parse the
+    /// header/footer). The `File` backing is read positionally via `with_block`.
+    #[inline]
+    fn bytes(&self) -> &[u8] {
+        match self {
+            DenseData::Owned(v) => &v[..],
+            DenseData::File(_) => unreachable!("File-backed db is read via with_block"),
+        }
+    }
+}
+
+/// An opened two-stage database. Construction loads only the stage-1 sparse
+/// index (the bincoded footer); per-genome dense blocks are decoded on demand,
+/// in parallel (each decode positionally reads its own block, no shared cursor
+/// or lock).
+pub struct TwoStageDb {
+    pub c: usize,
+    pub k: usize,
+    pub screen_c: usize,
+    /// File offset where the dense-block region ends (start of the footer); used
+    /// to bound the last genome's block for positional reads.
+    footer_offset: u64,
+    genomes: Vec<GenomeMeta>,
+    /// Stage-1 sparse sketches, one per genome, in database order. These stand in
+    /// for the full database during the cheap screen.
+    pub screen_sketches: Vec<GenomeSketch>,
+    data: DenseData,
+    cache: Mutex<FxHashMap<u32, Arc<GenomeSketch>>>,
+}
+
+/// Parse the magic + version header; return the footer offset.
+fn parse_header(hdr: &[u8]) -> io::Result<u64> {
+    if hdr.len() < HEADER_LEN as usize || &hdr[0..4] != MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not a sylph two-stage database",
+        ));
+    }
+    if hdr[4] != VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unsupported two-stage database version",
+        ));
+    }
+    Ok(u64::from_le_bytes(hdr[5..13].try_into().unwrap()))
+}
+
+/// Assemble a `TwoStageDb` from its parsed footer + backing store.
+fn build_db(footer: Footer, footer_offset: u64, data: DenseData) -> TwoStageDb {
+    // Build the stage-1 screen sketches from the sparse subsamples. The screen
+    // pass runs with pseudotax disabled, so an empty tracked-kmer set is a safe
+    // placeholder that keeps the `--disable-profiling` guard in `contain` happy;
+    // the true pseudotax k-mers come from the dense blocks.
+    let screen_sketches: Vec<GenomeSketch> = footer
+        .genomes
+        .iter()
+        .map(|m| GenomeSketch {
+            genome_kmers: m.sparse_kmers.clone(),
+            pseudotax_tracked_nonused_kmers: Some(Vec::new()),
+            file_name: m.file_name.clone(),
+            first_contig_name: m.first_contig_name.clone(),
+            c: footer.screen_c,
+            k: footer.k,
+            gn_size: m.gn_size,
+            min_spacing: m.min_spacing,
+        })
+        .collect();
+    TwoStageDb {
+        c: footer.c,
+        k: footer.k,
+        screen_c: footer.screen_c,
+        footer_offset,
+        genomes: footer.genomes,
+        screen_sketches,
+        data,
+        cache: Mutex::new(FxHashMap::default()),
+    }
+}
+
+/// Parse the header + footer of a `.syl2db` already resident in `data`.
+fn from_bytes(data: DenseData) -> io::Result<TwoStageDb> {
+    let bytes = data.bytes();
+    let footer_offset = parse_header(bytes)?;
+    if footer_offset as usize > bytes.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "two-stage database footer offset out of range",
+        ));
+    }
+    let footer: Footer = bincode::deserialize(&bytes[footer_offset as usize..])
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(build_db(footer, footer_offset, data))
+}
+
+/// Open a `.syl2db` from an in-memory reader (reads it all into memory).
+pub fn open<R: Read>(mut r: R) -> io::Result<TwoStageDb> {
+    let mut v = Vec::new();
+    r.read_to_end(&mut v)?;
+    from_bytes(DenseData::Owned(v))
+}
+
+impl TwoStageDb {
+    pub fn len(&self) -> usize {
+        self.genomes.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.genomes.is_empty()
+    }
+
+    /// End offset of genome `g`'s region (start of the next genome's block, or
+    /// the footer for the last genome). Genomes are stored in ascending offset.
+    fn block_end(&self, g: u32) -> u64 {
+        let gi = g as usize;
+        if gi + 1 < self.genomes.len() {
+            self.genomes[gi + 1].dense_offset
+        } else {
+            self.footer_offset
+        }
+    }
+
+    /// Run `f` on genome `g`'s whole on-disk region (`genome_kmers` block, the
+    /// pseudotax flag, and the optional pseudotax block). For the file backing
+    /// this is one positional read of just that region; for the owned backing it
+    /// is a zero-copy slice. No shared cursor, so it is safe to call concurrently
+    /// from many threads.
+    fn with_block<T>(&self, g: u32, f: impl FnOnce(&[u8]) -> io::Result<T>) -> io::Result<T> {
+        let start = self.genomes[g as usize].dense_offset as usize;
+        match &self.data {
+            DenseData::Owned(v) => f(&v[start..]),
+            DenseData::File(file) => {
+                let end = self.block_end(g) as usize;
+                let mut buf = vec![0u8; end - start];
+                file.read_exact_at(&mut buf, start as u64)?;
+                f(&buf)
+            }
+        }
+    }
+
+    /// Decode genome `g`'s full dense `GenomeSketch` without touching the cache.
+    /// Concurrent calls from different threads do not contend on any shared
+    /// cursor (each does its own positional read). The two-stage pass-1 uses this
+    /// to decode each survivor into a short-lived sketch, probe it, and drop it
+    /// unless it passes -- so the discarded majority is never cached.
+    pub fn decode_dense(&self, g: u32) -> io::Result<GenomeSketch> {
+        let meta = &self.genomes[g as usize];
+        let (genome_kmers, pseudotax) = self.with_block(g, |bytes| {
+            let mut cur = bytes;
+            let gk = read_hashes(&mut cur)?;
+            let mut flag = [0u8; 1];
+            cur.read_exact(&mut flag)?;
+            let pt = if flag[0] != 0 {
+                Some(read_hashes(&mut cur)?)
+            } else {
+                None
+            };
+            Ok((gk, pt))
+        })?;
+        Ok(GenomeSketch {
+            genome_kmers,
+            pseudotax_tracked_nonused_kmers: pseudotax,
+            file_name: meta.file_name.clone(),
+            first_contig_name: meta.first_contig_name.clone(),
+            c: self.c,
+            k: self.k,
+            gn_size: meta.gn_size,
+            min_spacing: meta.min_spacing,
+        })
+    }
+
+    /// Decode genome `g`'s full dense `GenomeSketch`, caching it across calls.
+    pub fn load_dense(&self, g: u32) -> io::Result<Arc<GenomeSketch>> {
+        if let Some(a) = self.cache.lock().unwrap().get(&g) {
+            return Ok(a.clone());
+        }
+        let sketch = Arc::new(self.decode_dense(g)?);
+        self.cache.lock().unwrap().insert(g, sketch.clone());
+        Ok(sketch)
+    }
+}
+
+/// Open a `.syl2db` file from a path. Only the header + footer (the stage-1
+/// sparse index) are read up front; dense blocks are read positionally on demand
+/// during profiling, so opening is cheap and RSS stays low.
+pub fn open_file(path: &str) -> io::Result<TwoStageDb> {
+    let file = File::open(path)?;
+    let mut hdr = [0u8; HEADER_LEN as usize];
+    file.read_exact_at(&mut hdr, 0)?;
+    let footer_offset = parse_header(&hdr)?;
+    let flen = file.metadata()?.len();
+    if footer_offset > flen {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "two-stage database footer offset out of range",
+        ));
+    }
+    let mut fbytes = vec![0u8; (flen - footer_offset) as usize];
+    file.read_exact_at(&mut fbytes, footer_offset)?;
+    let footer: Footer =
+        bincode::deserialize(&fbytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(build_db(footer, footer_offset, DenseData::File(file)))
+}
+
+// --- CLI handler ------------------------------------------------------------
+
+fn load_genome_sketches(path: &str) -> Vec<GenomeSketch> {
+    let file = File::open(path).unwrap_or_else(|_| panic!("Could not open {}", path));
+    let reader = BufReader::with_capacity(10_000_000, file);
+    bincode::deserialize_from(reader)
+        .unwrap_or_else(|_| panic!("{} is not a valid database sketch (.syldb)", path))
+}
+
+pub fn run_db_convert(args: DbConvertArgs) {
+    let level = if args.trace {
+        log::LevelFilter::Trace
+    } else if args.debug {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
+    };
+    simple_logger::SimpleLogger::new()
+        .with_level(level)
+        .init()
+        .unwrap();
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(args.threads)
+        .build_global()
+        .ok();
+
+    if args.files.is_empty() {
+        error!("No genome database sketches (*.syldb) supplied; exiting");
+        std::process::exit(1);
+    }
+
+    let mut sketches: Vec<GenomeSketch> = Vec::new();
+    for f in &args.files {
+        info!("Loading genome sketches from {}", f);
+        sketches.extend(load_genome_sketches(f));
+    }
+    if sketches.is_empty() {
+        error!("No genome sketches found in input; exiting");
+        std::process::exit(1);
+    }
+
+    let c = sketches[0].c;
+    let k = sketches[0].k;
+    for s in &sketches {
+        if s.c != c || s.k != k {
+            error!("Input sketches have inconsistent -c/-k; exiting");
+            std::process::exit(1);
+        }
+    }
+    if sketches
+        .iter()
+        .any(|s| s.pseudotax_tracked_nonused_kmers.is_none())
+    {
+        error!(
+            "Some input genomes were sketched with --disable-profiling (no profiling k-mers). \
+             A two-stage database is for `profile`; re-sketch without --disable-profiling. Exiting"
+        );
+        std::process::exit(1);
+    }
+    if args.screen_c < c {
+        error!(
+            "--screen-c ({}) must be >= the database -c ({}); the screen can only be made sparser, never denser. Exiting",
+            args.screen_c, c
+        );
+        std::process::exit(1);
+    }
+
+    let out = if args.output.ends_with(TWO_STAGE_DB_SUFFIX) {
+        args.output.clone()
+    } else {
+        format!("{}{}", args.output, TWO_STAGE_DB_SUFFIX)
+    };
+    if let Some(parent) = Path::new(&out).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).ok();
+        }
+    }
+    info!(
+        "Converting {} genomes (dense -c {}, stage-1 screen -c {}) -> {}",
+        sketches.len(),
+        c,
+        args.screen_c,
+        out
+    );
+    let w =
+        BufWriter::new(File::create(&out).unwrap_or_else(|_| panic!("Could not create {}", out)));
+    write_two_stage_db(w, &sketches, args.screen_c)
+        .unwrap_or_else(|e| panic!("Failed to write {}: {}", out, e));
+    info!("Wrote two-stage database to {}", out);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip_hashes(input: &[u64]) {
+        let mut expected = input.to_vec();
+        expected.sort_unstable();
+        let mut buf = Vec::new();
+        write_hashes(&mut buf, input);
+        let mut r = &buf[..];
+        assert_eq!(read_hashes(&mut r).unwrap(), expected);
+        assert!(r.is_empty(), "read_hashes left trailing bytes");
+    }
+
+    #[test]
+    fn hashes_roundtrip_various() {
+        roundtrip_hashes(&[]);
+        roundtrip_hashes(&[0]);
+        roundtrip_hashes(&[42]);
+        roundtrip_hashes(&[5, 5, 5]); // duplicates -> zero gaps
+        roundtrip_hashes(&[u64::MAX, 0, 1, u64::MAX / 2]);
+        roundtrip_hashes(&[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+        // many uniformly-spread hashes (the realistic FracMinHash case)
+        let mut v = Vec::new();
+        let mut x = 0xdead_beef_u64;
+        for _ in 0..5000 {
+            x = x
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            v.push(x >> 8); // keep them in a sub-range like a fracminhash threshold
+        }
+        roundtrip_hashes(&v);
+    }
+
+    fn gsketch(name: &str, kmers: Vec<u64>, pt: Option<Vec<u64>>) -> GenomeSketch {
+        GenomeSketch {
+            genome_kmers: kmers,
+            pseudotax_tracked_nonused_kmers: pt,
+            file_name: name.to_string(),
+            first_contig_name: format!("{}_c1", name),
+            c: 50,
+            k: 31,
+            gn_size: 12345,
+            min_spacing: 30,
+        }
+    }
+
+    #[test]
+    fn db_write_open_load_roundtrip() {
+        // screen_c = 200 (coarser than c = 50): the sparse subset keeps hashes
+        // below u64::MAX/200.
+        let thresh = u64::MAX / 200;
+        let g0_kmers: Vec<u64> = vec![1, 2, 3, thresh - 1, thresh + 10, thresh * 3, 9_000_000_000];
+        let g1_kmers: Vec<u64> = vec![7, thresh + 1, thresh * 2, 123_456_789_000];
+        let sketches = vec![
+            gsketch("g0.fa", g0_kmers.clone(), Some(vec![100, 200, 300])),
+            gsketch("g1.fa", g1_kmers.clone(), Some(vec![])),
+        ];
+
+        let mut buf = Vec::new();
+        write_two_stage_db(&mut buf, &sketches, 200).unwrap();
+        let db = open(std::io::Cursor::new(buf)).unwrap();
+
+        assert_eq!(db.c, 50);
+        assert_eq!(db.k, 31);
+        assert_eq!(db.screen_c, 200);
+        assert_eq!(db.len(), 2);
+
+        // stage-1 sparse sketch = fracminhash subset at screen_c
+        let expect_sparse = |ks: &[u64]| -> Vec<u64> {
+            let mut v: Vec<u64> = ks.iter().copied().filter(|&h| h < thresh).collect();
+            v.sort_unstable();
+            v
+        };
+        let mut s0 = db.screen_sketches[0].genome_kmers.clone();
+        s0.sort_unstable();
+        assert_eq!(s0, expect_sparse(&g0_kmers));
+        assert_eq!(db.screen_sketches[0].c, 200);
+
+        // stage-2 dense block reconstructs the exact genome k-mers + pseudotax
+        let d0 = db.load_dense(0).unwrap();
+        let mut got = d0.genome_kmers.clone();
+        got.sort_unstable();
+        let mut exp = g0_kmers.clone();
+        exp.sort_unstable();
+        assert_eq!(got, exp);
+        assert_eq!(d0.c, 50);
+        assert_eq!(d0.k, 31);
+        assert_eq!(d0.gn_size, 12345);
+        assert_eq!(d0.file_name, "g0.fa");
+        assert_eq!(
+            d0.pseudotax_tracked_nonused_kmers,
+            Some(vec![100, 200, 300])
+        );
+
+        let d1 = db.load_dense(1).unwrap();
+        let mut got1 = d1.genome_kmers.clone();
+        got1.sort_unstable();
+        let mut exp1 = g1_kmers.clone();
+        exp1.sort_unstable();
+        assert_eq!(got1, exp1);
+        assert_eq!(d1.pseudotax_tracked_nonused_kmers, Some(vec![]));
+
+        // second load hits the cache and returns the same data
+        let d0b = db.load_dense(0).unwrap();
+        assert_eq!(d0b.genome_kmers, d0.genome_kmers);
+    }
+}

--- a/src/twostage_db.rs
+++ b/src/twostage_db.rs
@@ -139,51 +139,88 @@ impl BitWriter {
     }
 }
 
+/// LSB-first bit reader that decodes a word at a time: bytes are buffered into a
+/// 64-bit accumulator so `read_bits`/`read_unary` extract many bits per
+/// instruction (shift/mask, trailing_ones) instead of one bit per call.
 struct BitReader<'a> {
     buf: &'a [u8],
-    byte: usize,
-    bit: u8,
+    pos: usize,
+    acc: u64,
+    nbits: u32,
 }
 
 impl<'a> BitReader<'a> {
     fn new(buf: &'a [u8]) -> Self {
         BitReader {
             buf,
-            byte: 0,
-            bit: 0,
+            pos: 0,
+            acc: 0,
+            nbits: 0,
         }
     }
+    /// Pull bytes into the accumulator until it holds >= 56 bits (so it never
+    /// exceeds 63, keeping shifts in range) or the input is exhausted.
     #[inline]
-    fn read_bit(&mut self) -> io::Result<u32> {
-        if self.byte >= self.buf.len() {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "bitstream truncated",
-            ));
+    fn refill(&mut self) {
+        while self.nbits < 56 && self.pos < self.buf.len() {
+            self.acc |= (self.buf[self.pos] as u64) << self.nbits;
+            self.pos += 1;
+            self.nbits += 8;
         }
-        let b = (self.buf[self.byte] >> self.bit) & 1;
-        self.bit += 1;
-        if self.bit == 8 {
-            self.bit = 0;
-            self.byte += 1;
-        }
-        Ok(b as u32)
     }
     #[inline]
     fn read_bits(&mut self, n: u32) -> io::Result<u64> {
-        let mut v = 0u64;
-        for i in 0..n {
-            v |= (self.read_bit()? as u64) << i;
+        if n == 0 {
+            return Ok(0);
         }
+        if n > 32 {
+            // Split so each half fits the (>=56 bit) accumulator comfortably.
+            let lo = self.read_bits(32)?;
+            let hi = self.read_bits(n - 32)?;
+            return Ok(lo | (hi << 32));
+        }
+        if self.nbits < n {
+            self.refill();
+            if self.nbits < n {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "bitstream truncated",
+                ));
+            }
+        }
+        let v = self.acc & ((1u64 << n) - 1);
+        self.acc >>= n;
+        self.nbits -= n;
         Ok(v)
     }
+    /// Unary = run of 1s terminated by a 0 (matches `BitWriter::write_unary`).
     #[inline]
     fn read_unary(&mut self) -> io::Result<u64> {
         let mut q = 0u64;
-        while self.read_bit()? == 1 {
-            q += 1;
+        loop {
+            if self.nbits == 0 {
+                self.refill();
+                if self.nbits == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "bitstream truncated",
+                    ));
+                }
+            }
+            let ones = (self.acc | (1u64 << self.nbits)).trailing_ones(); // <= nbits
+            if ones >= self.nbits {
+                // all buffered bits are 1s; consume them and continue
+                q += self.nbits as u64;
+                self.acc = 0;
+                self.nbits = 0;
+            } else {
+                // `ones` 1-bits then the terminating 0
+                q += ones as u64;
+                self.acc >>= ones + 1;
+                self.nbits -= ones + 1;
+                return Ok(q);
+            }
         }
-        Ok(q)
     }
 }
 

--- a/src/twostage_db.rs
+++ b/src/twostage_db.rs
@@ -9,8 +9,7 @@
 //! simpler:
 //!
 //!   * **No k-mer dereplication.** Each genome keeps its *own complete* k-mer set;
-//!     a k-mer shared by several genomes is stored in each of them. We do not
-//!     assign each k-mer a single owner.
+//!     a k-mer shared by several genomes is stored in each of them.
 //!   * **No shared/pooled hashes.** There is no conserved-k-mer pool.
 //!
 //! ## Layout
@@ -18,18 +17,25 @@
 //! ```text
 //! [4]  magic  "SY2D"
 //! [1]  version
+//! [8]  index_offset  (u64 LE)
 //! [8]  footer_offset (u64 LE)
 //! ---- body ----
 //! dense block 0, dense block 1, ...      (each: Golomb-Rice compressed)
+//! ---- index ----
+//! ScreenIndex                            (pooled-MPHF stage-1 screen index)
 //! ---- footer ----
-//! bincode(Footer)                        (the sparse stage-1 index + metadata)
+//! bincode(Footer)                        (per-genome metadata)
 //! ```
 //!
-//! **Stage 1 (sparse, bincoded, loaded fully).** The footer is a bincoded
-//! `Footer` holding, per genome, a FracMinHash subsample of its k-mers at a
-//! coarser rate `screen_c` (the same thresholding `subsample_view` uses, so the
-//! sparse set is a genuine sparser sketch). Querying a sample against these tiny
-//! sketches yields the genomes it contains.
+//! **Stage 1 (pooled MPHF, loaded fully).** The `ScreenIndex` is one minimal
+//! perfect hash over the *distinct* sparse (`screen_c`) k-mers of all genomes,
+//! with a multi-owner CSR mapping each sparse k-mer to the list of genomes that
+//! carry it. A sample is screened by a single pass over its k-mers (work ∝
+//! sample, not reference): each sample k-mer is looked up once and its coverage
+//! pushed to every owning genome. The contained genomes are exactly those a
+//! per-genome `get_stats` screen would find -- this is the "Path B" organisation
+//! (see `experiments/7_mphf_screen_again`), but multi-owner because `.syl2db`
+//! keeps shared k-mers.
 //!
 //! **Stage 2 (dense, Golomb-Rice, loaded on demand).** Each genome's *full*
 //! `genome_kmers` and `pseudotax_tracked_nonused_kmers` are an independently
@@ -40,6 +46,7 @@
 use crate::cmdline::DbConvertArgs;
 use crate::constants::*;
 use crate::types::*;
+use boomphf::Mphf;
 use fxhash::FxHashMap;
 use log::*;
 use std::fs::File;
@@ -49,10 +56,13 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 const MAGIC: &[u8; 4] = b"SY2D";
-/// Format version (dense blocks are Golomb-Rice coded).
-const VERSION: u8 = 1;
-/// magic (4) + version (1) + footer offset (8)
-const HEADER_LEN: u64 = 13;
+/// Format version (dense Golomb-Rice blocks + pooled-MPHF stage-1 screen index).
+const VERSION: u8 = 2;
+/// magic (4) + version (1) + index offset (8) + footer offset (8)
+const HEADER_LEN: u64 = 21;
+/// boomphf construction gamma (space/speed trade-off), matching the ref-delta
+/// sparse index.
+const MPHF_GAMMA: f64 = 2.0;
 
 // --- primitive integer / bit coding -----------------------------------------
 
@@ -288,9 +298,9 @@ fn read_hashes<R: Read>(r: &mut R) -> io::Result<Vec<u64>> {
 
 // --- footer (stage-1 sparse index + metadata) -------------------------------
 
-/// Per-genome metadata plus the stage-1 sparse k-mer subsample. Everything here
-/// is loaded into memory when the database is opened; the dense block at
-/// `dense_offset` is decoded lazily.
+/// Per-genome metadata. Everything here is loaded into memory when the database
+/// is opened; the dense block at `dense_offset` is decoded lazily. The stage-1
+/// sparse k-mers live in the pooled `ScreenIndex`, not here.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct GenomeMeta {
     pub file_name: String,
@@ -299,8 +309,6 @@ pub struct GenomeMeta {
     pub min_spacing: usize,
     pub has_pseudotax: bool,
     pub dense_offset: u64,
-    /// FracMinHash subsample of `genome_kmers` at `screen_c` (stage-1 screen).
-    pub sparse_kmers: Vec<u64>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
@@ -311,6 +319,206 @@ pub struct Footer {
     /// Sparse stage-1 screen rate (`screen_c >= c`).
     pub screen_c: usize,
     pub genomes: Vec<GenomeMeta>,
+}
+
+// --- stage-1 pooled-MPHF screen index ---------------------------------------
+
+#[inline]
+fn sparse_fingerprint(h: u64) -> u32 {
+    (h ^ (h >> 32)) as u32
+}
+
+/// FracMinHash threshold for the stage-1 screen: a k-mer is "sparse" iff its
+/// hash is `< u64::MAX / screen_c` (the same rule as `subsample_view` and the
+/// `.syl2db` build).
+#[inline]
+pub(crate) fn screen_threshold(screen_c: usize) -> u64 {
+    u64::MAX / screen_c.max(1) as u64
+}
+
+/// Pooled stage-1 screen index: one MPHF over the distinct sparse k-mers of all
+/// genomes, plus a multi-owner CSR (a k-mer may belong to several genomes).
+/// Owners are a *multiset* -- a genome appears once per occurrence of the k-mer
+/// in its sparse set -- so duplicate k-mers count exactly as the per-genome
+/// `get_stats` loop would.
+pub struct ScreenIndex {
+    pub screen_c: usize,
+    pub k: usize,
+    mphf: Mphf<u64>,
+    /// Per slot: fingerprint of the k-mer, to reject foreign (non-indexed) hashes
+    /// that the MPHF would otherwise map to an arbitrary slot.
+    fingerprints: Vec<u32>,
+    /// CSR row offsets, length `n_slots + 1`.
+    owner_offsets: Vec<u32>,
+    /// CSR owner genome ids (flat); slot `s` owns `owners[off[s]..off[s+1]]`.
+    owners: Vec<u32>,
+    /// Per genome: number of sparse k-mers (the `n_kmers` ANI denominator).
+    pub sparse_count: Vec<u32>,
+}
+
+impl ScreenIndex {
+    /// Build from each genome's sparse (`screen_c`) k-mers. Owners are kept as a
+    /// multiset so the screen reproduces the per-genome `get_stats` counts
+    /// exactly (including any duplicate k-mers within a genome).
+    pub fn build(sparse_per_genome: &[Vec<u64>], screen_c: usize, k: usize) -> ScreenIndex {
+        let sparse_count: Vec<u32> = sparse_per_genome.iter().map(|v| v.len() as u32).collect();
+        let total: usize = sparse_per_genome.iter().map(|v| v.len()).sum();
+
+        // (k-mer, genome) pairs, sorted so equal k-mers form contiguous runs.
+        let mut pairs: Vec<(u64, u32)> = Vec::with_capacity(total);
+        for (g, v) in sparse_per_genome.iter().enumerate() {
+            for &h in v {
+                pairs.push((h, g as u32));
+            }
+        }
+        pairs.sort_unstable();
+
+        // Distinct keys for the MPHF.
+        let mut keys: Vec<u64> = Vec::new();
+        for &(h, _) in &pairs {
+            if keys.last() != Some(&h) {
+                keys.push(h);
+            }
+        }
+        let mphf = Mphf::new_parallel(MPHF_GAMMA, &keys, Some(0));
+        let n_slots = keys.len();
+
+        // Per-slot owner counts -> CSR offsets.
+        let mut fingerprints = vec![0u32; n_slots];
+        let mut owner_offsets = vec![0u32; n_slots + 1];
+        let mut i = 0;
+        while i < pairs.len() {
+            let h = pairs[i].0;
+            let mut j = i;
+            while j < pairs.len() && pairs[j].0 == h {
+                j += 1;
+            }
+            let slot = mphf.hash(&h) as usize;
+            fingerprints[slot] = sparse_fingerprint(h);
+            owner_offsets[slot + 1] = (j - i) as u32; // count, prefix-summed below
+            i = j;
+        }
+        for s in 0..n_slots {
+            owner_offsets[s + 1] += owner_offsets[s];
+        }
+
+        // Fill owners using a per-slot write cursor.
+        let mut owners = vec![0u32; total];
+        let mut cursor: Vec<u32> = owner_offsets[..n_slots].to_vec();
+        let mut i = 0;
+        while i < pairs.len() {
+            let h = pairs[i].0;
+            let slot = mphf.hash(&h) as usize;
+            let mut j = i;
+            while j < pairs.len() && pairs[j].0 == h {
+                owners[cursor[slot] as usize] = pairs[j].1;
+                cursor[slot] += 1;
+                j += 1;
+            }
+            i = j;
+        }
+
+        ScreenIndex {
+            screen_c,
+            k,
+            mphf,
+            fingerprints,
+            owner_offsets,
+            owners,
+            sparse_count,
+        }
+    }
+
+    pub fn num_genomes(&self) -> usize {
+        self.sparse_count.len()
+    }
+
+    /// Single inverted pass over the sample: for each sample k-mer below the
+    /// screen threshold with non-zero count, look it up and push its coverage to
+    /// every owning genome. Returns `genome -> matched coverage counts`, exactly
+    /// the per-genome `covs` a `get_stats(.., None, ..)` screen would collect.
+    pub fn gather_hits(&self, sample: &SequencesSketch) -> FxHashMap<u32, Vec<u32>> {
+        let thresh = screen_threshold(self.screen_c);
+        let mut hits: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+        for (&h, &cnt) in sample.kmer_counts.iter() {
+            if h >= thresh || cnt == 0 {
+                continue;
+            }
+            if let Some(slot) = self.mphf.try_hash(&h) {
+                let slot = slot as usize;
+                if slot < self.fingerprints.len()
+                    && self.fingerprints[slot] == sparse_fingerprint(h)
+                {
+                    let lo = self.owner_offsets[slot] as usize;
+                    let hi = self.owner_offsets[slot + 1] as usize;
+                    for &g in &self.owners[lo..hi] {
+                        hits.entry(g).or_default().push(cnt);
+                    }
+                }
+            }
+        }
+        hits
+    }
+
+    /// Serialize the index into `out` (raw little-endian blocks).
+    fn write_to_vec(&self, out: &mut Vec<u8>) -> io::Result<()> {
+        let mphf_bytes = bincode::serialize(&self.mphf).map_err(io::Error::other)?;
+        write_uvarint(out, mphf_bytes.len() as u64);
+        out.extend_from_slice(&mphf_bytes);
+        write_uvarint(out, self.fingerprints.len() as u64); // n_slots
+        write_uvarint(out, self.owners.len() as u64);
+        write_uvarint(out, self.sparse_count.len() as u64); // n_genomes
+        for &fp in &self.fingerprints {
+            out.extend_from_slice(&fp.to_le_bytes());
+        }
+        for &o in &self.owner_offsets {
+            out.extend_from_slice(&o.to_le_bytes());
+        }
+        for &o in &self.owners {
+            out.extend_from_slice(&o.to_le_bytes());
+        }
+        for &c in &self.sparse_count {
+            out.extend_from_slice(&c.to_le_bytes());
+        }
+        Ok(())
+    }
+
+    /// Parse an index block produced by `write_to_vec`. `screen_c`/`k` come from
+    /// the footer (not duplicated in the block).
+    fn read(mut r: &[u8], screen_c: usize, k: usize) -> io::Result<ScreenIndex> {
+        let mphf_len = read_uvarint(&mut r)? as usize;
+        let mut mphf_bytes = vec![0u8; mphf_len];
+        r.read_exact(&mut mphf_bytes)?;
+        let mphf: Mphf<u64> = bincode::deserialize(&mphf_bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let n_slots = read_uvarint(&mut r)? as usize;
+        let n_owners = read_uvarint(&mut r)? as usize;
+        let n_genomes = read_uvarint(&mut r)? as usize;
+
+        let read_u32_vec = |r: &mut &[u8], n: usize| -> io::Result<Vec<u32>> {
+            let mut v = Vec::with_capacity(n);
+            for _ in 0..n {
+                let mut buf = [0u8; 4];
+                r.read_exact(&mut buf)?;
+                v.push(u32::from_le_bytes(buf));
+            }
+            Ok(v)
+        };
+        let fingerprints = read_u32_vec(&mut r, n_slots)?;
+        let owner_offsets = read_u32_vec(&mut r, n_slots + 1)?;
+        let owners = read_u32_vec(&mut r, n_owners)?;
+        let sparse_count = read_u32_vec(&mut r, n_genomes)?;
+
+        Ok(ScreenIndex {
+            screen_c,
+            k,
+            mphf,
+            fingerprints,
+            owner_offsets,
+            owners,
+            sparse_count,
+        })
+    }
 }
 
 // --- writing ----------------------------------------------------------------
@@ -334,6 +542,7 @@ pub fn write_two_stage_db<W: Write>(
 
     let mut body: Vec<u8> = Vec::new();
     let mut genomes: Vec<GenomeMeta> = Vec::with_capacity(sketches.len());
+    let mut sparse_per_genome: Vec<Vec<u64>> = Vec::with_capacity(sketches.len());
 
     for gs in sketches {
         let dense_offset = HEADER_LEN + body.len() as u64;
@@ -345,12 +554,13 @@ pub fn write_two_stage_db<W: Write>(
             }
             None => body.push(0),
         }
-        let sparse_kmers: Vec<u64> = gs
-            .genome_kmers
-            .iter()
-            .copied()
-            .filter(|&h| h < thresh)
-            .collect();
+        sparse_per_genome.push(
+            gs.genome_kmers
+                .iter()
+                .copied()
+                .filter(|&h| h < thresh)
+                .collect(),
+        );
         genomes.push(GenomeMeta {
             file_name: gs.file_name.clone(),
             first_contig_name: gs.first_contig_name.clone(),
@@ -358,9 +568,14 @@ pub fn write_two_stage_db<W: Write>(
             min_spacing: gs.min_spacing,
             has_pseudotax: gs.pseudotax_tracked_nonused_kmers.is_some(),
             dense_offset,
-            sparse_kmers,
         });
     }
+
+    // Pooled stage-1 screen index, then footer metadata.
+    let screen_index = ScreenIndex::build(&sparse_per_genome, screen_c, k);
+    drop(sparse_per_genome);
+    let mut index_block: Vec<u8> = Vec::new();
+    screen_index.write_to_vec(&mut index_block)?;
 
     let footer = Footer {
         c,
@@ -369,12 +584,15 @@ pub fn write_two_stage_db<W: Write>(
         genomes,
     };
     let footer_bytes = bincode::serialize(&footer).map_err(io::Error::other)?;
-    let footer_offset = HEADER_LEN + body.len() as u64;
+    let index_offset = HEADER_LEN + body.len() as u64;
+    let footer_offset = index_offset + index_block.len() as u64;
 
     w.write_all(MAGIC)?;
     w.write_all(&[VERSION])?;
+    w.write_all(&index_offset.to_le_bytes())?;
     w.write_all(&footer_offset.to_le_bytes())?;
     w.write_all(&body)?;
+    w.write_all(&index_block)?;
     w.write_all(&footer_bytes)?;
     Ok(())
 }
@@ -412,19 +630,19 @@ pub struct TwoStageDb {
     pub c: usize,
     pub k: usize,
     pub screen_c: usize,
-    /// File offset where the dense-block region ends (start of the footer); used
-    /// to bound the last genome's block for positional reads.
-    footer_offset: u64,
+    /// File offset where the dense-block region ends (start of the screen index);
+    /// used to bound the last genome's block for positional reads.
+    index_offset: u64,
     genomes: Vec<GenomeMeta>,
-    /// Stage-1 sparse sketches, one per genome, in database order. These stand in
-    /// for the full database during the cheap screen.
-    pub screen_sketches: Vec<GenomeSketch>,
+    /// Pooled stage-1 screen index (Path B). Replaces the per-genome sparse
+    /// sketches; querying a sample against it yields the contained genomes.
+    pub screen_index: ScreenIndex,
     data: DenseData,
     cache: Mutex<FxHashMap<u32, Arc<GenomeSketch>>>,
 }
 
-/// Parse the magic + version header; return the footer offset.
-fn parse_header(hdr: &[u8]) -> io::Result<u64> {
+/// Parse the magic + version header; return `(index_offset, footer_offset)`.
+fn parse_header(hdr: &[u8]) -> io::Result<(u64, u64)> {
     if hdr.len() < HEADER_LEN as usize || &hdr[0..4] != MAGIC {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -437,54 +655,48 @@ fn parse_header(hdr: &[u8]) -> io::Result<u64> {
             "unsupported two-stage database version",
         ));
     }
-    Ok(u64::from_le_bytes(hdr[5..13].try_into().unwrap()))
+    let index_offset = u64::from_le_bytes(hdr[5..13].try_into().unwrap());
+    let footer_offset = u64::from_le_bytes(hdr[13..21].try_into().unwrap());
+    Ok((index_offset, footer_offset))
 }
 
-/// Assemble a `TwoStageDb` from its parsed footer + backing store.
-fn build_db(footer: Footer, footer_offset: u64, data: DenseData) -> TwoStageDb {
-    // Build the stage-1 screen sketches from the sparse subsamples. The screen
-    // pass runs with pseudotax disabled, so an empty tracked-kmer set is a safe
-    // placeholder that keeps the `--disable-profiling` guard in `contain` happy;
-    // the true pseudotax k-mers come from the dense blocks.
-    let screen_sketches: Vec<GenomeSketch> = footer
-        .genomes
-        .iter()
-        .map(|m| GenomeSketch {
-            genome_kmers: m.sparse_kmers.clone(),
-            pseudotax_tracked_nonused_kmers: Some(Vec::new()),
-            file_name: m.file_name.clone(),
-            first_contig_name: m.first_contig_name.clone(),
-            c: footer.screen_c,
-            k: footer.k,
-            gn_size: m.gn_size,
-            min_spacing: m.min_spacing,
-        })
-        .collect();
+/// Assemble a `TwoStageDb` from its parsed footer + screen index + backing store.
+fn build_db(
+    footer: Footer,
+    index_offset: u64,
+    screen_index: ScreenIndex,
+    data: DenseData,
+) -> TwoStageDb {
     TwoStageDb {
         c: footer.c,
         k: footer.k,
         screen_c: footer.screen_c,
-        footer_offset,
+        index_offset,
         genomes: footer.genomes,
-        screen_sketches,
+        screen_index,
         data,
         cache: Mutex::new(FxHashMap::default()),
     }
 }
 
-/// Parse the header + footer of a `.syl2db` already resident in `data`.
+/// Parse the header + index + footer of a `.syl2db` already resident in `data`.
 fn from_bytes(data: DenseData) -> io::Result<TwoStageDb> {
     let bytes = data.bytes();
-    let footer_offset = parse_header(bytes)?;
-    if footer_offset as usize > bytes.len() {
+    let (index_offset, footer_offset) = parse_header(bytes)?;
+    if index_offset > footer_offset || footer_offset as usize > bytes.len() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            "two-stage database footer offset out of range",
+            "two-stage database offsets out of range",
         ));
     }
     let footer: Footer = bincode::deserialize(&bytes[footer_offset as usize..])
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-    Ok(build_db(footer, footer_offset, data))
+    let screen_index = ScreenIndex::read(
+        &bytes[index_offset as usize..footer_offset as usize],
+        footer.screen_c,
+        footer.k,
+    )?;
+    Ok(build_db(footer, index_offset, screen_index, data))
 }
 
 /// Open a `.syl2db` from an in-memory reader (reads it all into memory).
@@ -502,14 +714,20 @@ impl TwoStageDb {
         self.genomes.is_empty()
     }
 
+    /// Source file name of genome `g` (for `--screen-dump` and diagnostics).
+    pub fn genome_file_name(&self, g: u32) -> &str {
+        &self.genomes[g as usize].file_name
+    }
+
     /// End offset of genome `g`'s region (start of the next genome's block, or
-    /// the footer for the last genome). Genomes are stored in ascending offset.
+    /// the screen index for the last genome). Genomes are stored in ascending
+    /// offset, and the index block immediately follows the last dense block.
     fn block_end(&self, g: u32) -> u64 {
         let gi = g as usize;
         if gi + 1 < self.genomes.len() {
             self.genomes[gi + 1].dense_offset
         } else {
-            self.footer_offset
+            self.index_offset
         }
     }
 
@@ -580,19 +798,27 @@ pub fn open_file(path: &str) -> io::Result<TwoStageDb> {
     let file = File::open(path)?;
     let mut hdr = [0u8; HEADER_LEN as usize];
     file.read_exact_at(&mut hdr, 0)?;
-    let footer_offset = parse_header(&hdr)?;
+    let (index_offset, footer_offset) = parse_header(&hdr)?;
     let flen = file.metadata()?.len();
-    if footer_offset > flen {
+    if index_offset > footer_offset || footer_offset > flen {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            "two-stage database footer offset out of range",
+            "two-stage database offsets out of range",
         ));
     }
     let mut fbytes = vec![0u8; (flen - footer_offset) as usize];
     file.read_exact_at(&mut fbytes, footer_offset)?;
     let footer: Footer =
         bincode::deserialize(&fbytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-    Ok(build_db(footer, footer_offset, DenseData::File(file)))
+    let mut ibytes = vec![0u8; (footer_offset - index_offset) as usize];
+    file.read_exact_at(&mut ibytes, index_offset)?;
+    let screen_index = ScreenIndex::read(&ibytes, footer.screen_c, footer.k)?;
+    Ok(build_db(
+        footer,
+        index_offset,
+        screen_index,
+        DenseData::File(file),
+    ))
 }
 
 // --- CLI handler ------------------------------------------------------------
@@ -754,16 +980,21 @@ mod tests {
         assert_eq!(db.screen_c, 200);
         assert_eq!(db.len(), 2);
 
-        // stage-1 sparse sketch = fracminhash subset at screen_c
+        // stage-1 index: per-genome sparse count = fracminhash subset size at screen_c
         let expect_sparse = |ks: &[u64]| -> Vec<u64> {
             let mut v: Vec<u64> = ks.iter().copied().filter(|&h| h < thresh).collect();
             v.sort_unstable();
             v
         };
-        let mut s0 = db.screen_sketches[0].genome_kmers.clone();
-        s0.sort_unstable();
-        assert_eq!(s0, expect_sparse(&g0_kmers));
-        assert_eq!(db.screen_sketches[0].c, 200);
+        assert_eq!(db.screen_c, 200);
+        assert_eq!(
+            db.screen_index.sparse_count[0] as usize,
+            expect_sparse(&g0_kmers).len()
+        );
+        assert_eq!(
+            db.screen_index.sparse_count[1] as usize,
+            expect_sparse(&g1_kmers).len()
+        );
 
         // stage-2 dense block reconstructs the exact genome k-mers + pseudotax
         let d0 = db.load_dense(0).unwrap();
@@ -792,5 +1023,105 @@ mod tests {
         // second load hits the cache and returns the same data
         let d0b = db.load_dense(0).unwrap();
         assert_eq!(d0b.genome_kmers, d0.genome_kmers);
+    }
+
+    fn sample_from(counts: &[(u64, u32)]) -> SequencesSketch {
+        let mut s = SequencesSketch::new(String::new(), 50, 31, false, None, 0.0);
+        for &(h, c) in counts {
+            s.kmer_counts.insert(h, c);
+        }
+        s
+    }
+
+    /// `gather_hits` must reproduce, per genome, the exact coverage multiset that
+    /// the per-genome `get_stats` loop collects: intersection of the genome's
+    /// sparse k-mers with the sample, with duplicate k-mers counted per
+    /// occurrence and shared k-mers credited to every owner.
+    #[test]
+    fn screen_index_matches_per_genome_intersection() {
+        let screen_c = 100usize;
+        let thresh = screen_threshold(screen_c);
+        // All below threshold so every k-mer is "sparse". g0 has a duplicate (5);
+        // 5 and 9 are shared across genomes.
+        let sparse = vec![
+            vec![5u64, 5, 9, 11],  // g0: duplicate 5
+            vec![9u64, 11, 20],    // g1
+            vec![5u64, 30, 40, 9], // g2
+        ];
+        for v in &sparse {
+            assert!(v.iter().all(|&h| h < thresh));
+        }
+        let idx = ScreenIndex::build(&sparse, screen_c, 31);
+        assert_eq!(idx.sparse_count, vec![4u32, 3, 4]);
+
+        // Sample: some matching k-mers (with counts), a zero-count k-mer (ignored),
+        // a k-mer above threshold (ignored), and a foreign k-mer (no owner).
+        let sample = sample_from(&[
+            (5, 7),
+            (9, 3),
+            (11, 2),
+            (40, 9),
+            (99, 0),         // zero count -> ignored
+            (thresh + 1, 5), // above screen threshold -> ignored
+            (123456, 4),     // foreign -> no owner
+        ]);
+
+        let hits = idx.gather_hits(&sample);
+
+        // Brute-force per-genome reference (mirrors get_stats winner_map=None).
+        let mut expected: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+        for (g, v) in sparse.iter().enumerate() {
+            for &h in v {
+                if h < thresh {
+                    if let Some(&c) = sample.kmer_counts.get(&h) {
+                        if c != 0 {
+                            expected.entry(g as u32).or_default().push(c);
+                        }
+                    }
+                }
+            }
+        }
+        let norm = |m: &FxHashMap<u32, Vec<u32>>| -> Vec<(u32, Vec<u32>)> {
+            let mut out: Vec<(u32, Vec<u32>)> = m
+                .iter()
+                .map(|(&g, v)| {
+                    let mut v = v.clone();
+                    v.sort_unstable();
+                    (g, v)
+                })
+                .collect();
+            out.sort();
+            out
+        };
+        assert_eq!(norm(&hits), norm(&expected));
+        // g0 sees 5 twice (duplicate) + 9 + 11 -> covs {7,7,3,2}
+        let mut g0 = hits[&0].clone();
+        g0.sort_unstable();
+        assert_eq!(g0, vec![2, 3, 7, 7]);
+    }
+
+    /// The index survives a serialize/parse round-trip through the file format.
+    #[test]
+    fn screen_index_roundtrips_through_db() {
+        let thresh = u64::MAX / 200;
+        let g0 = vec![5u64, 5, thresh - 1, thresh + 9]; // last is above screen thresh
+        let g1 = vec![5u64, 7, thresh - 2];
+        let sketches = vec![
+            gsketch("g0.fa", g0.clone(), Some(vec![1])),
+            gsketch("g1.fa", g1.clone(), Some(vec![2])),
+        ];
+        let mut buf = Vec::new();
+        write_two_stage_db(&mut buf, &sketches, 200).unwrap();
+        let db = open(std::io::Cursor::new(buf)).unwrap();
+
+        let sample = sample_from(&[(5, 4), (7, 6), (thresh - 1, 1), (thresh - 2, 9)]);
+        let hits = db.screen_index.gather_hits(&sample);
+        // g0: 5 twice + (thresh-1) once -> {4,4,1}; g1: 5 + 7 + (thresh-2) -> {4,6,9}
+        let mut g0h = hits[&0].clone();
+        g0h.sort_unstable();
+        assert_eq!(g0h, vec![1, 4, 4]);
+        let mut g1h = hits[&1].clone();
+        g1h.sort_unstable();
+        assert_eq!(g1h, vec![4, 6, 9]);
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -595,3 +595,147 @@ fn test_inspect(){
     assert!(stdout.contains("e.coli-K12.fasta.gz"));
 
 }
+
+#[serial]
+#[test]
+fn test_two_stage_profile(){
+    fresh();
+    let dir = "./tests/results/two_stage";
+    let _ = fs::remove_dir_all(dir);
+
+    // Sparse (-c 200) database that retains the source fasta paths.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("sketch").arg("-c").arg("200")
+        .arg("./test_files/e.coli-EC590.fasta.gz")
+        .arg("./test_files/e.coli-o157.fasta.gz")
+        .arg("./test_files/e.coli-K12.fasta.gz")
+        .arg("-o").arg(format!("{}/db_c200", dir))
+        .assert().success().code(0);
+
+    // Dense (-c 50) read sample.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("sketch").arg("-c").arg("50")
+        .arg("./test_files/o157_reads.fastq.gz")
+        .arg("-d").arg(dir)
+        .assert().success().code(0);
+
+    let db = format!("{}/db_c200.syldb", dir);
+    let sample = format!("{}/o157_reads.fastq.gz.sylsp", dir);
+    let cache = format!("{}/cache", dir);
+
+    // Two-stage profile: screen at c=200, densely profile the survivors at c=50
+    // by re-sketching their source fastas, caching the dense sketches.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    let output = cmd.arg("profile").arg("--two-stage")
+        .arg("--dense-c").arg("50")
+        .arg("--dense-cache").arg(&cache)
+        .arg(&db).arg(&sample)
+        .output().expect("Output failed");
+    assert!(output.status.success());
+    let two_stage = str::from_utf8(&output.stdout).expect("not UTF-8").to_string();
+    // The reads are E. coli O157 -> that genome must be profiled.
+    assert!(two_stage.contains("e.coli-o157.fasta.gz"));
+    // The dense stage caches a per-genome sketch for each screened survivor.
+    assert!(Path::new(&cache).exists());
+    assert!(fs::read_dir(&cache).unwrap().count() >= 1, "dense cache was not populated");
+
+    // Genomes detected by two-stage must equal those of a plain single-stage
+    // profile of the same dense reads against a dense (-c 50) database.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("sketch").arg("-c").arg("50")
+        .arg("./test_files/e.coli-EC590.fasta.gz")
+        .arg("./test_files/e.coli-o157.fasta.gz")
+        .arg("./test_files/e.coli-K12.fasta.gz")
+        .arg("-o").arg(format!("{}/db_c50", dir))
+        .assert().success().code(0);
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    let output = cmd.arg("profile")
+        .arg(format!("{}/db_c50.syldb", dir)).arg(&sample)
+        .output().expect("Output failed");
+    let single = str::from_utf8(&output.stdout).expect("not UTF-8").to_string();
+
+    let detected = |tsv: &str| -> Vec<String> {
+        let mut v: Vec<String> = tsv.lines().skip(1)
+            .filter_map(|l| l.split('\t').nth(1).map(|s| s.to_string()))
+            .collect();
+        v.sort();
+        v
+    };
+    assert_eq!(detected(&two_stage), detected(&single),
+        "two-stage and single-stage detected different genome sets");
+}
+
+#[serial]
+#[test]
+fn test_two_stage_db_convert_and_profile(){
+    fresh();
+    let dir = "./tests/results/two_stage_db";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    // Dense (-c 50) database carrying profiling k-mers.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("sketch").arg("-c").arg("50")
+        .arg("./test_files/e.coli-EC590.fasta.gz")
+        .arg("./test_files/e.coli-o157.fasta.gz")
+        .arg("./test_files/e.coli-K12.fasta.gz")
+        .arg("-o").arg(format!("{}/db_c50", dir))
+        .assert().success().code(0);
+
+    // Dense (-c 50) read sample.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("sketch").arg("-c").arg("50")
+        .arg("./test_files/o157_reads.fastq.gz")
+        .arg("-d").arg(dir)
+        .assert().success().code(0);
+
+    let dense_db = format!("{}/db_c50.syldb", dir);
+    let sample = format!("{}/o157_reads.fastq.gz.sylsp", dir);
+
+    // Convert the dense db into a two-stage seekable database: dense blocks at
+    // c=50, sparse stage-1 screen index at c=200.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("db-convert")
+        .arg(&dense_db)
+        .arg("--screen-c").arg("200")
+        .arg("-o").arg(format!("{}/db2", dir))
+        .assert().success().code(0);
+    let two_stage_db = format!("{}/db2.syl2db", dir);
+    assert!(Path::new(&two_stage_db).exists(), "db-convert did not produce a .syl2db");
+    // The two-stage db should be no larger than the dense .syldb it came from
+    // (dense blocks are Golomb-Rice compressed; only the small sparse index adds).
+    let dense_sz = fs::metadata(&dense_db).unwrap().len();
+    let two_sz = fs::metadata(&two_stage_db).unwrap().len();
+    assert!(two_sz < dense_sz, "compressed two-stage db ({} B) not smaller than dense db ({} B)", two_sz, dense_sz);
+
+    // Profile --two-stage directly against the .syl2db: stage 1 screens via the
+    // sparse index, stage 2 decodes only the screened genomes' dense blocks.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    let output = cmd.arg("profile").arg("--two-stage")
+        .arg(&two_stage_db).arg(&sample)
+        .output().expect("Output failed");
+    assert!(output.status.success());
+    let from_db2 = str::from_utf8(&output.stdout).expect("not UTF-8").to_string();
+    assert!(from_db2.contains("e.coli-o157.fasta.gz"));
+
+    // The detected genome set must equal a plain single-stage dense profile.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    let output = cmd.arg("profile")
+        .arg(&dense_db).arg(&sample)
+        .output().expect("Output failed");
+    let single = str::from_utf8(&output.stdout).expect("not UTF-8").to_string();
+
+    let detected = |tsv: &str| -> Vec<String> {
+        let mut v: Vec<String> = tsv.lines().skip(1)
+            .filter_map(|l| l.split('\t').nth(1).map(|s| s.to_string()))
+            .collect();
+        v.sort();
+        v
+    };
+    assert_eq!(detected(&from_db2), detected(&single),
+        "two-stage .syl2db and single-stage detected different genome sets");
+
+    // `query` must refuse a .syl2db (it is profile-only).
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("query").arg(&two_stage_db).arg(&sample).assert().failure();
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -739,3 +739,78 @@ fn test_two_stage_db_convert_and_profile(){
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     cmd.arg("query").arg(&two_stage_db).arg(&sample).assert().failure();
 }
+
+#[serial]
+#[test]
+fn test_two_stage_individual_records(){
+    fresh();
+    let dir = "./tests/results/two_stage_indiv";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    // Dense (-c 50) database built with --individual-records: e.coli-o157 has two
+    // records, so multiple database entries share one file name -- the case that
+    // must be preserved per record by db-convert (and rejected by the densify
+    // fallback).
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("sketch").arg("-c").arg("50").arg("-i")
+        .arg("./test_files/e.coli-EC590.fasta.gz")
+        .arg("./test_files/e.coli-o157.fasta.gz")
+        .arg("./test_files/e.coli-K12.fasta.gz")
+        .arg("-o").arg(format!("{}/db_c50", dir))
+        .assert().success().code(0);
+
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("sketch").arg("-c").arg("50")
+        .arg("./test_files/o157_reads.fastq.gz")
+        .arg("-d").arg(dir)
+        .assert().success().code(0);
+
+    let dense_db = format!("{}/db_c50.syldb", dir);
+    let sample = format!("{}/o157_reads.fastq.gz.sylsp", dir);
+
+    // Convert to a two-stage db (per-record blocks are written individually).
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("db-convert").arg(&dense_db)
+        .arg("--screen-c").arg("200")
+        .arg("-o").arg(format!("{}/db2", dir))
+        .assert().success().code(0);
+    let two_stage_db = format!("{}/db2.syl2db", dir);
+
+    // Per-record key = genome_file (col 2) + contig name (last col).
+    let detected = |tsv: &str| -> Vec<String> {
+        let mut v: Vec<String> = tsv.lines().skip(1)
+            .filter_map(|l| {
+                let cols: Vec<&str> = l.split('\t').collect();
+                if cols.len() < 2 { return None; }
+                Some(format!("{}\t{}", cols[1], cols[cols.len() - 1]))
+            })
+            .collect();
+        v.sort();
+        v
+    };
+
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    let two = cmd.arg("profile").arg("--two-stage").arg(&two_stage_db).arg(&sample)
+        .output().expect("Output failed");
+    assert!(two.status.success());
+    let two = str::from_utf8(&two.stdout).expect("not UTF-8").to_string();
+    assert!(two.contains("e.coli-o157.fasta.gz"));
+
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    let single = cmd.arg("profile").arg(&dense_db).arg(&sample)
+        .output().expect("Output failed");
+    let single = str::from_utf8(&single.stdout).expect("not UTF-8").to_string();
+
+    // db-convert + two-stage must reproduce single-stage per-record detections
+    // (no collapsing/merging of records sharing a file name).
+    assert_eq!(detected(&two), detected(&single),
+        "two-stage .syl2db lost or merged individual records vs single-stage");
+
+    // The densify fallback (raw .syldb --two-stage, no db-convert) cannot handle
+    // individual records and must error rather than silently corrupt them.
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
+    cmd.arg("profile").arg("--two-stage").arg("--dense-c").arg("50")
+        .arg(&dense_db).arg(&sample)
+        .assert().failure();
+}


### PR DESCRIPTION

Hi,

Here's the result of some messing around with AI I did. It seems to be a straight up win for profiling by CPU, RAM and database disk size compared to the main branch, particularly for simple communities, though it does make the CLI interface and codebase a bit more complex. It might be a good idea to update the version of the current genome database, rather than create a new `syl2db`, but I'll leave that decision to you.

Results are **identical** to single-stage profiling, while profiling is
**~7–27× faster** and uses **~6× less RAM** (a flat ~4.4 GB vs the whole ~26 GB
database), and the on-disk database is **~22% smaller**.

See below comment at https://github.com/bluenote-1577/sylph/pull/79#issuecomment-4871091268 for an updated description of the PR.

Thanks,
ben
