### PR TITLE
cargo fmt, clippy --fix.

### DIFF
--- a/src/avx2_seeding.rs
+++ b/src/avx2_seeding.rs
@@ -1,5 +1,5 @@
-use std::arch::x86_64::*;
 use crate::types::*;
+use std::arch::x86_64::*;
 
 #[inline]
 #[target_feature(enable = "avx2")]
@@ -26,7 +26,7 @@ pub unsafe fn mm_hash256(kmer: __m256i) -> __m256i {
     let s6 = _mm256_slli_epi64(key, 31);
     key = _mm256_add_epi64(key, s6);
 
-    return key;
+    key
 }
 
 #[target_feature(enable = "avx2")]
@@ -39,7 +39,7 @@ pub unsafe fn extract_markers_avx2(string: &[u8], kmer_vec: &mut Vec<u64>, c: us
     let string2 = &string[len..2 * len + k - 1];
     let string3 = &string[2 * len..3 * len + k - 1];
     let string4 = &string[3 * len..4 * len + k - 1];
-    if string.len() < k+1{
+    if string.len() < k + 1 {
         return;
     }
 
@@ -78,7 +78,7 @@ pub unsafe fn extract_markers_avx2(string: &[u8], kmer_vec: &mut Vec<u64>, c: us
     }
 
     let marker_mask = (Kmer::MAX >> (std::mem::size_of::<Kmer>() * 8 - 2 * k)) as i64;
-    let rev_marker_mask: i64 = !(0 | (3 << 2 * k - 2));
+    let rev_marker_mask: i64 = !(3 << (2 * k - 2));
     //    let rev_marker_mask = i64::from_le_bytes(rev_marker_mask.to_le_bytes());
     //    dbg!(u64::MAX / (c as u64));
     //    dbg!((u64::MAX / (c as u64)) as i64);
@@ -148,7 +148,13 @@ pub unsafe fn extract_markers_avx2(string: &[u8], kmer_vec: &mut Vec<u64>, c: us
 }
 
 #[target_feature(enable = "avx2")]
-pub unsafe fn extract_markers_avx2_positions(string: &[u8], kmer_vec: &mut Vec<(usize, usize,u64)>, c: usize, k: usize, contig_number: usize) {
+pub unsafe fn extract_markers_avx2_positions(
+    string: &[u8],
+    kmer_vec: &mut Vec<(usize, usize, u64)>,
+    c: usize,
+    k: usize,
+    contig_number: usize,
+) {
     if string.len() < k {
         return;
     }
@@ -196,7 +202,7 @@ pub unsafe fn extract_markers_avx2_positions(string: &[u8], kmer_vec: &mut Vec<(
     }
 
     let marker_mask = (Kmer::MAX >> (std::mem::size_of::<Kmer>() * 8 - 2 * k)) as i64;
-    let rev_marker_mask: i64 = !(0 | (3 << 2 * k - 2));
+    let rev_marker_mask: i64 = !(3 << (2 * k - 2));
     //    let rev_marker_mask = i64::from_le_bytes(rev_marker_mask.to_le_bytes());
     //    dbg!(u64::MAX / (c as u64));
     //    dbg!((u64::MAX / (c as u64)) as i64);
@@ -257,10 +263,10 @@ pub unsafe fn extract_markers_avx2_positions(string: &[u8], kmer_vec: &mut Vec<(
             kmer_vec.push((contig_number, len + i, v2 as u64));
         }
         if v3 < threshold_marker {
-            kmer_vec.push((contig_number, 2*len + i, v3 as u64));
+            kmer_vec.push((contig_number, 2 * len + i, v3 as u64));
         }
         if v4 < threshold_marker {
-            kmer_vec.push((contig_number, 3*len + i, v4 as u64));
+            kmer_vec.push((contig_number, 3 * len + i, v4 as u64));
         }
     }
 }

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,22 +1,28 @@
-use clap::{Args, Parser, Subcommand};
 use crate::constants::*;
+use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
-#[clap(author, version, about = "Ultrafast genome ANI queries and taxonomic profiling for metagenomic shotgun samples.\n\n--- Preparing inputs by sketching (indexing)\n## fastq (reads) and fasta (genomes all at once)\n## *.sylsp found in -d; *.syldb given by -o\nsylph sketch -t 5 sample1.fq sample2.fq genome1.fa genome2.fa -o genome1+genome2 -d sample_dir\n\n## paired-end reads\nsylph sketch -1 a_1.fq b_1.fq -2 b_2.fq b_2.fq -d paired_sketches\n\n--- Nearest neighbour containment ANI\nsylph query *.syldb *.sylsp > all-to-all-query.tsv\n\n--- Taxonomic profiling with relative abundances and ANI\nsylph profile *.syldb *.sylsp > all-to-all-profile.tsv", arg_required_else_help = true, disable_help_subcommand = true)]
+#[clap(
+    author,
+    version,
+    about = "Ultrafast genome ANI queries and taxonomic profiling for metagenomic shotgun samples.\n\n--- Preparing inputs by sketching (indexing)\n## fastq (reads) and fasta (genomes all at once)\n## *.sylsp found in -d; *.syldb given by -o\nsylph sketch -t 5 sample1.fq sample2.fq genome1.fa genome2.fa -o genome1+genome2 -d sample_dir\n\n## paired-end reads\nsylph sketch -1 a_1.fq b_1.fq -2 b_2.fq b_2.fq -d paired_sketches\n\n--- Nearest neighbour containment ANI\nsylph query *.syldb *.sylsp > all-to-all-query.tsv\n\n--- Taxonomic profiling with relative abundances and ANI\nsylph profile *.syldb *.sylsp > all-to-all-profile.tsv",
+    arg_required_else_help = true,
+    disable_help_subcommand = true
+)]
 pub struct Cli {
-    #[clap(subcommand,)]
+    #[clap(subcommand)]
     pub mode: Mode,
 }
 
 #[derive(Subcommand)]
 pub enum Mode {
-    /// Sketch sequences into samples (reads) and databases (genomes). Each sample.fq -> sample.sylsp. All *.fa -> *.syldb. 
+    /// Sketch sequences into samples (reads) and databases (genomes). Each sample.fq -> sample.sylsp. All *.fa -> *.syldb.
     #[clap(display_order = 1)]
     Sketch(SketchArgs),
     /// Coverage-adjusted ANI querying between databases and samples.
     #[clap(display_order = 3)]
     Query(ContainArgs),
-    ///Species-level taxonomic profiling with abundances and ANIs. 
+    ///Species-level taxonomic profiling with abundances and ANIs.
     #[clap(display_order = 2)]
     Profile(ContainArgs),
     ///Inspect sketched .syldb and .sylsp files.
@@ -24,153 +30,365 @@ pub enum Mode {
     Inspect(InspectArgs),
 }
 
-
 #[derive(Args, Default)]
 pub struct SketchArgs {
-    #[clap(multiple=true, help_heading = "INPUT", help = "fasta/fastq files; gzip optional. Default: fastq file produces a sample sketch (*.sylsp) while fasta files are combined into a database (*.syldb).")]
+    #[clap(
+        multiple = true,
+        help_heading = "INPUT",
+        help = "fasta/fastq files; gzip optional. Default: fastq file produces a sample sketch (*.sylsp) while fasta files are combined into a database (*.syldb)."
+    )]
     pub files: Vec<String>,
-    #[clap(short='o',long="out-name-db", default_value = "database", help_heading = "OUTPUT", help = "Output name for database sketch (with .syldb appended)")]
+    #[clap(
+        short = 'o',
+        long = "out-name-db",
+        default_value = "database",
+        help_heading = "OUTPUT",
+        help = "Output name for database sketch (with .syldb appended)"
+    )]
     pub db_out_name: String,
-    #[clap(short='d',long="sample-output-directory", default_value = "./", help_heading = "OUTPUT", help = "Output directory for sample sketches")]
+    #[clap(
+        short = 'd',
+        long = "sample-output-directory",
+        default_value = "./",
+        help_heading = "OUTPUT",
+        help = "Output directory for sample sketches"
+    )]
     pub sample_output_dir: String,
-    #[clap(short,long="individual-records", help_heading = "GENOME INPUT", help = "Use individual records (contigs) for database construction")]
+    #[clap(
+        short,
+        long = "individual-records",
+        help_heading = "GENOME INPUT",
+        help = "Use individual records (contigs) for database construction"
+    )]
     pub individual: bool,
-    #[clap(multiple=true,short,long="reads", help_heading = "SINGLE-END INPUT", help = "Single-end fasta/fastq reads")]
+    #[clap(
+        multiple = true,
+        short,
+        long = "reads",
+        help_heading = "SINGLE-END INPUT",
+        help = "Single-end fasta/fastq reads"
+    )]
     pub reads: Option<Vec<String>>,
-    #[clap(multiple=true,short='g', long="genomes", help_heading = "GENOME INPUT", help = "Genomes in fasta format")]
+    #[clap(
+        multiple = true,
+        short = 'g',
+        long = "genomes",
+        help_heading = "GENOME INPUT",
+        help = "Genomes in fasta format"
+    )]
     pub genomes: Option<Vec<String>>,
-    #[clap(short,long="list", help_heading = "INPUT", help = "Newline delimited file with inputs; fastas -> database, fastq -> sample")]
+    #[clap(
+        short,
+        long = "list",
+        help_heading = "INPUT",
+        help = "Newline delimited file with inputs; fastas -> database, fastq -> sample"
+    )]
     pub list_sequence: Option<String>,
-    #[clap(long="rl", hidden=true, help_heading = "SINGLE-END INPUT", help = "Newline delimited file; inputs assumed reads")]
+    #[clap(
+        long = "rl",
+        hidden = true,
+        help_heading = "SINGLE-END INPUT",
+        help = "Newline delimited file; inputs assumed reads"
+    )]
     pub list_reads: Option<String>,
-    #[clap(long="gl", help_heading = "GENOME INPUT", help = "Newline delimited file; inputs assumed genomes")]
+    #[clap(
+        long = "gl",
+        help_heading = "GENOME INPUT",
+        help = "Newline delimited file; inputs assumed genomes"
+    )]
     pub list_genomes: Option<String>,
-    #[clap(long="l1", help_heading = "PAIRED-END INPUT", help = "Newline delimited file; inputs are first pair of PE reads")]
+    #[clap(
+        long = "l1",
+        help_heading = "PAIRED-END INPUT",
+        help = "Newline delimited file; inputs are first pair of PE reads"
+    )]
     pub list_first_pair: Option<String>,
-    #[clap(long="l2", help_heading = "PAIRED-END INPUT", help = "Newline delimited file; inputs are second pair of PE reads")]
+    #[clap(
+        long = "l2",
+        help_heading = "PAIRED-END INPUT",
+        help = "Newline delimited file; inputs are second pair of PE reads"
+    )]
     pub list_second_pair: Option<String>,
-    #[clap(long="lS", help_heading = "INPUT", help = "Newline delimited file; read sketches are renamed to given sample names")]
+    #[clap(
+        long = "lS",
+        help_heading = "INPUT",
+        help = "Newline delimited file; read sketches are renamed to given sample names"
+    )]
     pub list_sample_names: Option<String>,
-    #[clap(multiple=true, short='S', long="sample-names", help_heading = "INPUT", help = "Read sketches are renamed to given sample names")]
+    #[clap(
+        multiple = true,
+        short = 'S',
+        long = "sample-names",
+        help_heading = "INPUT",
+        help = "Read sketches are renamed to given sample names"
+    )]
     pub sample_names: Option<Vec<String>>,
 
-    #[clap(short, default_value_t = 31,help_heading = "ALGORITHM", help ="Value of k. Only k = 21, 31 are currently supported")]
+    #[clap(
+        short,
+        default_value_t = 31,
+        help_heading = "ALGORITHM",
+        help = "Value of k. Only k = 21, 31 are currently supported"
+    )]
     pub k: usize,
-    #[clap(short, default_value_t = 200, help_heading = "ALGORITHM", help = "Subsampling rate")]
+    #[clap(
+        short,
+        default_value_t = 200,
+        help_heading = "ALGORITHM",
+        help = "Subsampling rate"
+    )]
     pub c: usize,
     #[clap(short, default_value_t = 3, help = "Number of threads")]
     pub threads: usize,
-    #[clap(long="ram-barrier", help = "Stop multi-threaded read sketching when (virtual) RAM is past this value (in GB). Does NOT guarantee max RAM limit", hidden=true)]
+    #[clap(
+        long = "ram-barrier",
+        help = "Stop multi-threaded read sketching when (virtual) RAM is past this value (in GB). Does NOT guarantee max RAM limit",
+        hidden = true
+    )]
     pub max_ram: Option<usize>,
-    #[clap(long="trace", help = "Trace output (caution: very verbose)")]
+    #[clap(long = "trace", help = "Trace output (caution: very verbose)")]
     pub trace: bool,
-    #[clap(long="debug", help = "Debug output")]
+    #[clap(long = "debug", help = "Debug output")]
     pub debug: bool,
 
-
-    #[clap(long="no-dedup", help_heading = "ALGORITHM", help = "Disable read deduplication procedure. Reduces memory; not recommended for illumina data")]
+    #[clap(
+        long = "no-dedup",
+        help_heading = "ALGORITHM",
+        help = "Disable read deduplication procedure. Reduces memory; not recommended for illumina data"
+    )]
     pub no_dedup: bool,
-    #[clap(long="disable-profiling", help_heading = "ALGORITHM", help = "Disable sylph profile usage for databases; may decrease size and make sylph query slightly faster", hidden=true)]
+    #[clap(
+        long = "disable-profiling",
+        help_heading = "ALGORITHM",
+        help = "Disable sylph profile usage for databases; may decrease size and make sylph query slightly faster",
+        hidden = true
+    )]
     pub no_pseudotax: bool,
-    #[clap(long="min-spacing", default_value_t = 30, help_heading = "ALGORITHM", help = "Minimum spacing between selected k-mers on the genomes")]
+    #[clap(
+        long = "min-spacing",
+        default_value_t = 30,
+        help_heading = "ALGORITHM",
+        help = "Minimum spacing between selected k-mers on the genomes"
+    )]
     pub min_spacing_kmer: usize,
     #[clap(long="fpr", default_value_t = DEFAULT_FPR, help_heading = "ALGORITHM", help = "False positive rate for read deduplicate hashing; valid values in [0,1).")]
     pub fpr: f64,
-    #[clap(short='1',long="first-pairs", multiple=true, help_heading = "PAIRED-END INPUT", help = "First pairs for paired end reads")]
+    #[clap(
+        short = '1',
+        long = "first-pairs",
+        multiple = true,
+        help_heading = "PAIRED-END INPUT",
+        help = "First pairs for paired end reads"
+    )]
     pub first_pair: Vec<String>,
-    #[clap(short='2',long="second-pairs", multiple=true, help_heading = "PAIRED-END INPUT", help = "Second pairs for paired end reads")]
+    #[clap(
+        short = '2',
+        long = "second-pairs",
+        multiple = true,
+        help_heading = "PAIRED-END INPUT",
+        help = "Second pairs for paired end reads"
+    )]
     pub second_pair: Vec<String>,
 }
 
 #[derive(Args)]
 pub struct ContainArgs {
-    #[clap(multiple=true, help = "Pre-sketched *.syldb/*.sylsp files. Raw single-end fastq/fasta are allowed and will be automatically sketched to .sylsp/.syldb")]
+    #[clap(
+        multiple = true,
+        help = "Pre-sketched *.syldb/*.sylsp files. Raw single-end fastq/fasta are allowed and will be automatically sketched to .sylsp/.syldb"
+    )]
     pub files: Vec<String>,
 
-    
-    #[clap(short='l',long="list", help = "Newline delimited file of file inputs",help_heading = "INPUT/OUTPUT")]
+    #[clap(
+        short = 'l',
+        long = "list",
+        help = "Newline delimited file of file inputs",
+        help_heading = "INPUT/OUTPUT"
+    )]
     pub file_list: Option<String>,
 
-    #[clap(long,default_value_t = 3., help_heading = "ALGORITHM", help = "Minimum k-mer multiplicity needed for coverage correction. Higher values gives more precision but lower sensitivity")]
+    #[clap(
+        long,
+        default_value_t = 3.,
+        help_heading = "ALGORITHM",
+        help = "Minimum k-mer multiplicity needed for coverage correction. Higher values gives more precision but lower sensitivity"
+    )]
     pub min_count_correct: f64,
-    #[clap(short='M',long,default_value_t = 50., help_heading = "ALGORITHM", help = "Exclude genomes with less than this number of sampled k-mers")]
+    #[clap(
+        short = 'M',
+        long,
+        default_value_t = 50.,
+        help_heading = "ALGORITHM",
+        help = "Exclude genomes with less than this number of sampled k-mers"
+    )]
     pub min_number_kmers: f64,
-    #[clap(short, long="minimum-ani", help_heading = "ALGORITHM", help = "Minimum adjusted ANI to consider (0-100). Default is 90 for query and 95 for profile. Smaller than 95 for profile will give inaccurate results." )]
+    #[clap(
+        short,
+        long = "minimum-ani",
+        help_heading = "ALGORITHM",
+        help = "Minimum adjusted ANI to consider (0-100). Default is 90 for query and 95 for profile. Smaller than 95 for profile will give inaccurate results."
+    )]
     pub minimum_ani: Option<f64>,
     #[clap(short, default_value_t = 3, help = "Number of threads")]
     pub threads: usize,
-    #[clap(short='s', long="sample-threads", help = "Number of samples to be processed concurrently. Default: (# of total threads / 3) + 1 for profile, 1 for query")]
+    #[clap(
+        short = 's',
+        long = "sample-threads",
+        help = "Number of samples to be processed concurrently. Default: (# of total threads / 3) + 1 for profile, 1 for query"
+    )]
     pub sample_threads: Option<usize>,
-    #[clap(long="trace", help = "Trace output (caution: very verbose)")]
+    #[clap(long = "trace", help = "Trace output (caution: very verbose)")]
     pub trace: bool,
-    #[clap(long="debug", help = "Debug output")]
+    #[clap(long = "debug", help = "Debug output")]
     pub debug: bool,
 
-    #[clap(long="estimate-read-counts", help_heading = "ALGORITHM", help = "Very roughly estimate read counts in the 'Sequence_abundance' column instead of relative abundance. This forces `-u`, which may have caveats for long reads and complex environments.")]
+    #[clap(
+        long = "estimate-read-counts",
+        help_heading = "ALGORITHM",
+        help = "Very roughly estimate read counts in the 'Sequence_abundance' column instead of relative abundance. This forces `-u`, which may have caveats for long reads and complex environments."
+    )]
     pub estimate_read_counts: bool,
 
-    #[clap(short='u', long="estimate-unknown", help_heading = "ALGORITHM", help = "Estimate true coverage and scale sequence abundance in `profile` by estimated unknown sequence percentage" )]
+    #[clap(
+        short = 'u',
+        long = "estimate-unknown",
+        help_heading = "ALGORITHM",
+        help = "Estimate true coverage and scale sequence abundance in `profile` by estimated unknown sequence percentage"
+    )]
     pub estimate_unknown: bool,
-    
-    #[clap(short='I',long="read-seq-id", help_heading = "ALGORITHM", help = "Sequence identity (%) of reads. Only used in -u option and overrides automatic detection. ")]
+
+    #[clap(
+        short = 'I',
+        long = "read-seq-id",
+        help_heading = "ALGORITHM",
+        help = "Sequence identity (%) of reads. Only used in -u option and overrides automatic detection. "
+    )]
     pub seq_id: Option<f64>,
 
     //#[clap(short='l', long="read-length", help_heading = "ALGORITHM", help = "Read length (single-end length for pairs). Only necessary for short-read coverages when using --estimate-unknown. Not needed for long-reads" )]
     //pub read_length: Option<usize>,
-
-    #[clap(short='R', long="redundancy-threshold", help_heading = "ALGORITHM", help = "Removes redundant genomes up to a rough ANI percentile when profiling", default_value_t = 99.0, hidden=true)]
+    #[clap(
+        short = 'R',
+        long = "redundancy-threshold",
+        help_heading = "ALGORITHM",
+        help = "Removes redundant genomes up to a rough ANI percentile when profiling",
+        default_value_t = 99.0,
+        hidden = true
+    )]
     pub redundant_ani: f64,
 
-    #[clap(short='r',long="reads", multiple=true, help = "Single-end raw reads (fastx/gzip)", display_order = 1, help_heading = "SKETCHING")]
+    #[clap(
+        short = 'r',
+        long = "reads",
+        multiple = true,
+        help = "Single-end raw reads (fastx/gzip)",
+        display_order = 1,
+        help_heading = "SKETCHING"
+    )]
     pub reads: Vec<String>,
 
-    #[clap(short='1', long="first-pairs", multiple=true, help = "First pairs for raw paired-end reads (fastx/gzip)", help_heading = "SKETCHING")]
+    #[clap(
+        short = '1',
+        long = "first-pairs",
+        multiple = true,
+        help = "First pairs for raw paired-end reads (fastx/gzip)",
+        help_heading = "SKETCHING"
+    )]
     pub first_pair: Vec<String>,
 
-    #[clap(short='2', long="second-pairs", multiple=true, help = "Second pairs for raw paired-end reads (fastx/gzip)", help_heading = "SKETCHING")]
+    #[clap(
+        short = '2',
+        long = "second-pairs",
+        multiple = true,
+        help = "Second pairs for raw paired-end reads (fastx/gzip)",
+        help_heading = "SKETCHING"
+    )]
     pub second_pair: Vec<String>,
 
-    #[clap(short, default_value_t = 200, help_heading = "SKETCHING", help = "Subsampling rate. Does nothing for pre-sketched files")]
+    #[clap(
+        short,
+        default_value_t = 200,
+        help_heading = "SKETCHING",
+        help = "Subsampling rate. Does nothing for pre-sketched files"
+    )]
     pub c: usize,
-    #[clap(short, default_value_t = 31, help_heading = "SKETCHING", help = "Value of k. Only k = 21, 31 are currently supported. Does nothing for pre-sketched files")]
+    #[clap(
+        short,
+        default_value_t = 31,
+        help_heading = "SKETCHING",
+        help = "Value of k. Only k = 21, 31 are currently supported. Does nothing for pre-sketched files"
+    )]
     pub k: usize,
-    #[clap(short,long="individual-records", help_heading = "SKETCHING", help = "Use individual records (e.g. contigs) for database construction instead. Does nothing for pre-sketched files")]
+    #[clap(
+        short,
+        long = "individual-records",
+        help_heading = "SKETCHING",
+        help = "Use individual records (e.g. contigs) for database construction instead. Does nothing for pre-sketched files"
+    )]
     pub individual: bool,
-    #[clap(long="min-spacing", default_value_t = 30, help_heading = "SKETCHING", help = "Minimum spacing between selected k-mers on the database genomes. Does nothing for pre-sketched files")]
+    #[clap(
+        long = "min-spacing",
+        default_value_t = 30,
+        help_heading = "SKETCHING",
+        help = "Minimum spacing between selected k-mers on the database genomes. Does nothing for pre-sketched files"
+    )]
     pub min_spacing_kmer: usize,
 
-    #[clap(short='o',long="output-file", help = "Output to this file (TSV format). [default: stdout]", help_heading="INPUT/OUTPUT")]
+    #[clap(
+        short = 'o',
+        long = "output-file",
+        help = "Output to this file (TSV format). [default: stdout]",
+        help_heading = "INPUT/OUTPUT"
+    )]
     pub out_file_name: Option<String>,
-    #[clap(long="log-reassignments", help = "Output information for how k-mers for genomes are reassigned during `profile`. Caution: can be verbose and slows down computation.")]
+    #[clap(
+        long = "log-reassignments",
+        help = "Output information for how k-mers for genomes are reassigned during `profile`. Caution: can be verbose and slows down computation."
+    )]
     pub log_reassignments: bool,
 
-
-    //Hidden options that are embedded in the args but no longer used... 
-    #[clap(short, hidden=true, long="pseudotax", help_heading = "ALGORITHM", help = "Pseudo taxonomic classification mode. This removes shared k-mers between species by assigning k-mers to the highest ANI species. Requires sketches with --enable-pseudotax option" )]
+    //Hidden options that are embedded in the args but no longer used...
+    #[clap(
+        short,
+        hidden = true,
+        long = "pseudotax",
+        help_heading = "ALGORITHM",
+        help = "Pseudo taxonomic classification mode. This removes shared k-mers between species by assigning k-mers to the highest ANI species. Requires sketches with --enable-pseudotax option"
+    )]
     pub pseudotax: bool,
-    #[clap(long="ratio", hidden=true)]
+    #[clap(long = "ratio", hidden = true)]
     pub ratio: bool,
-    #[clap(long="mme", hidden=true)]
+    #[clap(long = "mme", hidden = true)]
     pub mme: bool,
-    #[clap(long="mle", hidden=true)]
+    #[clap(long = "mle", hidden = true)]
     pub mle: bool,
-    #[clap(long="nb", hidden=true)]
+    #[clap(long = "nb", hidden = true)]
     pub nb: bool,
-    #[clap(long="no-ci", help = "Do not output confidence intervals", hidden=true)]
+    #[clap(
+        long = "no-ci",
+        help = "Do not output confidence intervals",
+        hidden = true
+    )]
     pub no_ci: bool,
-    #[clap(long="no-adjust", hidden=true)]
+    #[clap(long = "no-adjust", hidden = true)]
     pub no_adj: bool,
-    #[clap(long="mean-coverage", help_heading = "ALGORITHM", help = "Use the robust mean coverage estimator instead of median estimator", hidden=true )]
+    #[clap(
+        long = "mean-coverage",
+        help_heading = "ALGORITHM",
+        help = "Use the robust mean coverage estimator instead of median estimator",
+        hidden = true
+    )]
     pub mean_coverage: bool,
-
 }
 
 #[derive(Args)]
 pub struct InspectArgs {
-    #[clap(multiple=true, help = "Pre-sketched *.syldb/*.sylsp files.")]
+    #[clap(multiple = true, help = "Pre-sketched *.syldb/*.sylsp files.")]
     pub files: Vec<String>,
-    #[clap(short='o',long="output-file", help = "Output to this file (YAML format). [default: stdout]")]
+    #[clap(
+        short = 'o',
+        long = "output-file",
+        help = "Output to this file (YAML format). [default: stdout]"
+    )]
     pub out_file_name: Option<String>,
-
 }
-    

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,12 +1,12 @@
 pub const EM_ABUND_CUTOFF: f64 = 0.01;
 pub const PAIR_REGEX: &str = r"(.+)(_?1|_?2)(\..+)";
-pub const CUTOFF_PVALUE:f64 = 0.9999999999;
+pub const CUTOFF_PVALUE: f64 = 0.9999999999;
 pub const SAMPLE_SIZE_CUTOFF: usize = 25;
 pub const MEDIAN_ANI_THRESHOLD: f64 = 2.;
 pub const QUERY_FILE_SUFFIX: &str = ".syldb";
 pub const SAMPLE_FILE_SUFFIX: &str = ".sylsp";
-pub const QUERY_FILE_SUFFIX_VALID : [&str;2] = [QUERY_FILE_SUFFIX, ".sylqueries"];
-pub const SAMPLE_FILE_SUFFIX_VALID : [&str;2] = [SAMPLE_FILE_SUFFIX, ".sylsample"];
+pub const QUERY_FILE_SUFFIX_VALID: [&str; 2] = [QUERY_FILE_SUFFIX, ".sylqueries"];
+pub const SAMPLE_FILE_SUFFIX_VALID: [&str; 2] = [SAMPLE_FILE_SUFFIX, ".sylsample"];
 pub const MIN_ANI_DEF: f64 = 0.9;
 pub const MIN_ANI_P_DEF: f64 = 0.95;
 pub const MAX_MEDIAN_FOR_MEAN_FINAL_EST: f64 = 15.;

--- a/src/contain.rs
+++ b/src/contain.rs
@@ -1,18 +1,18 @@
 use crate::cmdline::*;
-use std::path::Path;
-use std::io::prelude::*;
-use std::io;
-use std::io::BufWriter;
-use fxhash::FxHashMap;
 use crate::constants::*;
 use crate::inference::*;
 use crate::sketch::*;
 use crate::types::*;
+use fxhash::FxHashMap;
 use log::*;
 use rayon::prelude::*;
 use statrs::distribution::{DiscreteCDF, Poisson};
 use std::fs::File;
+use std::io;
+use std::io::prelude::*;
 use std::io::BufReader;
+use std::io::BufWriter;
+use std::path::Path;
 use std::sync::Mutex;
 
 fn print_ani_result(ani_result: &AniResult, pseudotax: bool, writer: &mut Box<dyn Write + Send>) {
@@ -21,9 +21,9 @@ fn print_ani_result(ani_result: &AniResult, pseudotax: bool, writer: &mut Box<dy
     if let AdjustStatus::Lambda(lambda) = ani_result.lambda {
         lambda_print = format!("{:.3}", lambda);
     } else if ani_result.lambda == AdjustStatus::High {
-        lambda_print = format!("HIGH");
+        lambda_print = "HIGH".to_string();
     } else {
-        lambda_print = format!("LOW");
+        lambda_print = "LOW".to_string();
     }
     let low_ani = ani_result.ani_ci.0;
     let high_ani = ani_result.ani_ci.1;
@@ -48,11 +48,11 @@ fn print_ani_result(ani_result: &AniResult, pseudotax: bool, writer: &mut Box<dy
         ci_lambda = format!("{:.2}-{:.2}", low_lambda.unwrap(), high_lambda.unwrap());
     }
 
-
     //"Sample_file\tQuery_file\tTaxonomic_abundance\tSequence_abundance\tAdjusted_ANI\tEff_cov\tANI_5-95_percentile\tEff_lambda\tLambda_5-95_percentile\tMedian_cov\tMean_cov_geq1\tContainment_ind\tNaive_ANI\tContig_name",
 
-    if !pseudotax{
-        writeln!(writer, 
+    if !pseudotax {
+        writeln!(
+            writer,
             "{}\t{}\t{}\t{:.3}\t{}\t{}\t{}\t{:.0}\t{:.3}\t{}/{}\t{:.2}\t{}",
             ani_result.seq_name,
             ani_result.gn_name,
@@ -67,10 +67,11 @@ fn print_ani_result(ani_result: &AniResult, pseudotax: bool, writer: &mut Box<dy
             ani_result.containment_index.1,
             ani_result.naive_ani * 100.,
             ani_result.contig_name,
-        ).expect("Error writing to file");
-    }
-    else{
-        writeln!(writer,
+        )
+        .expect("Error writing to file");
+    } else {
+        writeln!(
+            writer,
             "{}\t{}\t{:.4}\t{:.4}\t{}\t{:.3}\t{}\t{}\t{}\t{:.0}\t{:.3}\t{}/{}\t{:.2}\t{}\t{}",
             ani_result.seq_name,
             ani_result.gn_name,
@@ -88,12 +89,12 @@ fn print_ani_result(ani_result: &AniResult, pseudotax: bool, writer: &mut Box<dy
             ani_result.naive_ani * 100.,
             ani_result.kmers_lost.unwrap(),
             ani_result.contig_name,
-        ).expect("Error writing to file");
-
+        )
+        .expect("Error writing to file");
     }
 }
 
-fn get_chunks(indices: &Vec<usize>, steps: usize) -> Vec<Vec<usize>>{
+fn get_chunks(indices: &Vec<usize>, steps: usize) -> Vec<Vec<usize>> {
     let mut start = 0;
     let mut end = steps;
     let len = indices.len();
@@ -113,8 +114,7 @@ fn get_chunks(indices: &Vec<usize>, steps: usize) -> Vec<Vec<usize>>{
 }
 
 pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
-
-    if pseudotax_in{
+    if pseudotax_in {
         args.pseudotax = true;
     }
 
@@ -123,11 +123,10 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
         level = log::LevelFilter::Trace;
     } else if args.debug {
         level = log::LevelFilter::Debug;
-    }
-    else{
+    } else {
         level = log::LevelFilter::Info;
     }
-    
+
     simple_logger::SimpleLogger::new()
         .with_level(level)
         .init()
@@ -141,12 +140,12 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
     let out_writer = match args.out_file_name {
         Some(ref x) => {
             let path = Path::new(&x);
-            Box::new(BufWriter::new(File::create(&path).unwrap())) as Box<dyn Write + Send>
+            Box::new(BufWriter::new(File::create(path).unwrap())) as Box<dyn Write + Send>
         }
         None => Box::new(BufWriter::new(io::stdout())) as Box<dyn Write + Send>,
     };
 
-    if args.estimate_read_counts{
+    if args.estimate_read_counts {
         args.estimate_unknown = true;
         log::info!("--estimate-read-counts detected, also enabling -u. Sequence_abundance column will be set to estimated read counts, not abundance. This is still experimental.");
     }
@@ -159,41 +158,38 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
 
     let mut all_files = args.files.clone();
 
-    if let Some(ref newline_file) = args.file_list{
+    if let Some(ref newline_file) = args.file_list {
         let file = File::open(newline_file).unwrap();
         let reader = BufReader::new(file);
         for line in reader.lines() {
             all_files.push(line.unwrap());
         }
-
     }
 
-
-    for file in all_files.iter(){
-
+    for file in all_files.iter() {
         let mut genome_sketch_good_suffix = false;
-        for suff in QUERY_FILE_SUFFIX_VALID{
-            if file.ends_with(suff){
+        for suff in QUERY_FILE_SUFFIX_VALID {
+            if file.ends_with(suff) {
                 genome_sketch_good_suffix = true;
-                break
+                break;
             }
         }
 
         let mut sample_sketch_good_suffix = false;
-        for suff in SAMPLE_FILE_SUFFIX_VALID{
-            if file.ends_with(suff){
+        for suff in SAMPLE_FILE_SUFFIX_VALID {
+            if file.ends_with(suff) {
                 sample_sketch_good_suffix = true;
-                break
+                break;
             }
         }
 
-        if genome_sketch_good_suffix{
+        if genome_sketch_good_suffix {
             genome_sketch_files.push(file);
-        } else if sample_sketch_good_suffix{
+        } else if sample_sketch_good_suffix {
             read_sketch_files.push(file);
-        } else if is_fasta(&file) {
+        } else if is_fasta(file) {
             genome_files.push(file);
-        } else if is_fastq(&file) {
+        } else if is_fastq(file) {
             read_files.push(vec![file]);
         } else {
             warn!(
@@ -210,19 +206,19 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
 
     // zip together the first and second pair files, push them to read_files
     for (first, second) in args.first_pair.iter().zip(args.second_pair.iter()) {
-        read_files.push(vec![first,second]);
+        read_files.push(vec![first, second]);
     }
 
     for read in args.reads.iter() {
         read_files.push(vec![read]);
     }
 
-    if genome_sketch_files.is_empty() && genome_files.is_empty(){
+    if genome_sketch_files.is_empty() && genome_files.is_empty() {
         log::error!("No genome files found; see sylph query/profile -h for help. Exiting");
         std::process::exit(1);
     }
 
-    if read_sketch_files.is_empty() && read_files.is_empty(){
+    if read_sketch_files.is_empty() && read_files.is_empty() {
         log::error!("No read files found; see sylph query/profile -h for help. Exiting");
         std::process::exit(1);
     }
@@ -236,124 +232,210 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
         std::process::exit(1);
     }
 
-    if genome_sketches.first().unwrap().pseudotax_tracked_nonused_kmers.is_none() && args.pseudotax{
+    if genome_sketches
+        .first()
+        .unwrap()
+        .pseudotax_tracked_nonused_kmers
+        .is_none()
+        && args.pseudotax
+    {
         log::error!("Attempting profiling, but *.syldb was sketched with the --disable-profiling option. Exiting");
         std::process::exit(1);
     }
 
     let num_raw_read_files = read_files.len();
     let step;
-    if let Some(sample_threads) = args.sample_threads{
-        if sample_threads > 0{
+    if let Some(sample_threads) = args.sample_threads {
+        if sample_threads > 0 {
             step = sample_threads;
-        }
-        else{
+        } else {
             step = 1;
         }
-    }
-    else{
-        if args.pseudotax{
-            step = usize::max(args.threads/3 + 1, usize::min(num_raw_read_files, args.threads))
-        }
-        else{
+    } else {
+        if args.pseudotax {
+            step = usize::max(
+                args.threads / 3 + 1,
+                usize::min(num_raw_read_files, args.threads),
+            )
+        } else {
             step = usize::max(1, usize::min(num_raw_read_files, args.threads))
         }
     }
 
-    let read_sketch_files_as_vec = read_sketch_files.clone().into_iter().map(|x| vec![x]).collect::<Vec<Vec<&String>>>();
+    let read_sketch_files_as_vec = read_sketch_files
+        .clone()
+        .into_iter()
+        .map(|x| vec![x])
+        .collect::<Vec<Vec<&String>>>();
     read_files.extend(read_sketch_files_as_vec);
     let sequence_index_vec = (0..read_files.len()).collect::<Vec<usize>>();
-    let out_writer:Mutex<Box<dyn Write + Send>> = Mutex::new(out_writer);
+    let out_writer: Mutex<Box<dyn Write + Send>> = Mutex::new(out_writer);
 
     let chunks = get_chunks(&sequence_index_vec, step);
 
-    print_header(args.pseudotax,&mut *out_writer.lock().unwrap(), args.estimate_unknown);
+    print_header(
+        args.pseudotax,
+        &mut out_writer.lock().unwrap(),
+        args.estimate_unknown,
+    );
     chunks.into_iter().for_each(|chunk| {
-        chunk.into_par_iter().for_each(|j|{
+        chunk.into_par_iter().for_each(|j| {
             let is_sketch = j >= read_files.len() - read_sketch_files.len();
-            let sequence_sketch = get_seq_sketch(&args, &read_files[j], is_sketch, genome_sketches[0].c, genome_sketches[0].k);
-            if sequence_sketch.is_some(){
+            let sequence_sketch = get_seq_sketch(
+                &args,
+                &read_files[j],
+                is_sketch,
+                genome_sketches[0].c,
+                genome_sketches[0].k,
+            );
+            if sequence_sketch.is_some() {
                 let first_read_file = read_files[j][0];
                 let sequence_sketch = sequence_sketch.unwrap();
-                
+
                 let kmer_id_opt;
-                if args.seq_id.is_some(){
-                    kmer_id_opt = Some((args.seq_id.unwrap()/100.).powf(sequence_sketch.k as f64));
-                }
-                else{
+                if args.seq_id.is_some() {
+                    kmer_id_opt =
+                        Some((args.seq_id.unwrap() / 100.).powf(sequence_sketch.k as f64));
+                } else {
                     kmer_id_opt = get_kmer_identity(&sequence_sketch, args.estimate_unknown);
-                    log::debug!("{} has estimated identity {:.3}.", &first_read_file, kmer_id_opt.unwrap().powf(1./sequence_sketch.k as f64) * 100.);
+                    log::debug!(
+                        "{} has estimated identity {:.3}.",
+                        &first_read_file,
+                        kmer_id_opt.unwrap().powf(1. / sequence_sketch.k as f64) * 100.
+                    );
                 }
-                
+
                 let stats_vec_seq: Mutex<Vec<AniResult>> = Mutex::new(vec![]);
                 genome_index_vec.par_iter().for_each(|i| {
                     let genome_sketch = &genome_sketches[*i];
-                    let res = get_stats(&args, &genome_sketch, &sequence_sketch, None, args.log_reassignments);
+                    let res = get_stats(
+                        &args,
+                        genome_sketch,
+                        &sequence_sketch,
+                        None,
+                        args.log_reassignments,
+                    );
                     if res.is_some() {
                         //res.as_mut().unwrap().genome_sketch_index = *i;
                         stats_vec_seq.lock().unwrap().push(res.unwrap());
-                        
                     }
                 });
 
                 let mut stats_vec_seq = stats_vec_seq.into_inner().unwrap();
-                estimate_true_cov(&mut stats_vec_seq, kmer_id_opt, args.estimate_unknown, sequence_sketch.mean_read_length, sequence_sketch.k);
+                estimate_true_cov(
+                    &mut stats_vec_seq,
+                    kmer_id_opt,
+                    args.estimate_unknown,
+                    sequence_sketch.mean_read_length,
+                    sequence_sketch.k,
+                );
 
-                if args.pseudotax{
-                    log::info!("{} taxonomic profiling; reassigning k-mers for {} genomes...", &first_read_file, stats_vec_seq.len());
+                if args.pseudotax {
+                    log::info!(
+                        "{} taxonomic profiling; reassigning k-mers for {} genomes...",
+                        &first_read_file,
+                        stats_vec_seq.len()
+                    );
                     let winner_map = winner_table(&stats_vec_seq, args.log_reassignments);
-                    let remaining_genomes = stats_vec_seq.iter().map(|x| x.genome_sketch).collect::<Vec<&GenomeSketch>>();
+                    let remaining_genomes = stats_vec_seq
+                        .iter()
+                        .map(|x| x.genome_sketch)
+                        .collect::<Vec<&GenomeSketch>>();
                     let stats_vec_seq_2 = Mutex::new(vec![]);
-                    remaining_genomes.into_par_iter().for_each(|genome_sketch|{
-                        let res = get_stats(&args, &genome_sketch, &sequence_sketch, Some(&winner_map), args.log_reassignments);
+                    remaining_genomes.into_par_iter().for_each(|genome_sketch| {
+                        let res = get_stats(
+                            &args,
+                            genome_sketch,
+                            &sequence_sketch,
+                            Some(&winner_map),
+                            args.log_reassignments,
+                        );
                         if res.is_some() {
                             stats_vec_seq_2.lock().unwrap().push(res.unwrap());
                         }
                     });
-                    stats_vec_seq = derep_if_reassign_threshold(&stats_vec_seq, stats_vec_seq_2.into_inner().unwrap(), args.redundant_ani, sequence_sketch.k);
+                    stats_vec_seq = derep_if_reassign_threshold(
+                        &stats_vec_seq,
+                        stats_vec_seq_2.into_inner().unwrap(),
+                        args.redundant_ani,
+                        sequence_sketch.k,
+                    );
                     //stats_vec_seq = stats_vec_seq_2.into_inner().unwrap();
-                    estimate_true_cov(&mut stats_vec_seq, kmer_id_opt, args.estimate_unknown, sequence_sketch.mean_read_length, sequence_sketch.k);
-                    log::info!("{} has {} genomes passing profiling threshold. ", &first_read_file, stats_vec_seq.len());
+                    estimate_true_cov(
+                        &mut stats_vec_seq,
+                        kmer_id_opt,
+                        args.estimate_unknown,
+                        sequence_sketch.mean_read_length,
+                        sequence_sketch.k,
+                    );
+                    log::info!(
+                        "{} has {} genomes passing profiling threshold. ",
+                        &first_read_file,
+                        stats_vec_seq.len()
+                    );
 
                     let mut bases_explained = 1.;
-                    if args.estimate_unknown{
-                        bases_explained = estimate_covered_bases(&stats_vec_seq, &sequence_sketch, sequence_sketch.mean_read_length, sequence_sketch.k);
-                        log::info!("{} has {:.2}% of reads detected in database by profile", &first_read_file, bases_explained * 100.);
-                        
+                    if args.estimate_unknown {
+                        bases_explained = estimate_covered_bases(
+                            &stats_vec_seq,
+                            &sequence_sketch,
+                            sequence_sketch.mean_read_length,
+                            sequence_sketch.k,
+                        );
+                        log::info!(
+                            "{} has {:.2}% of reads detected in database by profile",
+                            &first_read_file,
+                            bases_explained * 100.
+                        );
                     }
 
                     let total_cov = stats_vec_seq.iter().map(|x| x.final_est_cov).sum::<f64>();
-                    let total_seq_cov = stats_vec_seq.iter().map(|x| x.final_est_cov * x.genome_sketch.gn_size as f64).sum::<f64>();
-                    for thing in stats_vec_seq.iter_mut(){
-                        thing.rel_abund = Some(thing.final_est_cov/total_cov * 100.);
+                    let total_seq_cov = stats_vec_seq
+                        .iter()
+                        .map(|x| x.final_est_cov * x.genome_sketch.gn_size as f64)
+                        .sum::<f64>();
+                    for thing in stats_vec_seq.iter_mut() {
+                        thing.rel_abund = Some(thing.final_est_cov / total_cov * 100.);
                     }
-                    for thing in stats_vec_seq.iter_mut(){
-                        if args.estimate_read_counts{
-                            thing.seq_abund = Some((thing.final_est_cov * thing.genome_sketch.gn_size as f64 / sequence_sketch.mean_read_length * bases_explained).round());
-                        }
-                        else{
-                            let seq_abund = thing.final_est_cov * thing.genome_sketch.gn_size as f64 / total_seq_cov * 100. * bases_explained;
+                    for thing in stats_vec_seq.iter_mut() {
+                        if args.estimate_read_counts {
+                            thing.seq_abund = Some(
+                                (thing.final_est_cov * thing.genome_sketch.gn_size as f64
+                                    / sequence_sketch.mean_read_length
+                                    * bases_explained)
+                                    .round(),
+                            );
+                        } else {
+                            let seq_abund = thing.final_est_cov
+                                * thing.genome_sketch.gn_size as f64
+                                / total_seq_cov
+                                * 100.
+                                * bases_explained;
                             thing.seq_abund = Some(seq_abund);
                         }
                     }
                 }
 
-                if args.pseudotax{
-                    stats_vec_seq.sort_by(|x,y| y.rel_abund.unwrap().partial_cmp(&x.rel_abund.unwrap()).unwrap());
+                if args.pseudotax {
+                    stats_vec_seq.sort_by(|x, y| {
+                        y.rel_abund
+                            .unwrap()
+                            .partial_cmp(&x.rel_abund.unwrap())
+                            .unwrap()
+                    });
+                } else {
+                    stats_vec_seq
+                        .sort_by(|x, y| y.final_est_ani.partial_cmp(&x.final_est_ani).unwrap());
                 }
-                else{
-                    stats_vec_seq.sort_by(|x,y| y.final_est_ani.partial_cmp(&x.final_est_ani).unwrap());
-                }
-                
+
                 let mut out_writer = out_writer.lock().unwrap();
-                for res in stats_vec_seq{
-                    print_ani_result(&res, args.pseudotax, &mut *out_writer);
+                for res in stats_vec_seq {
+                    print_ani_result(&res, args.pseudotax, &mut out_writer);
                 }
             }
-            if read_files[j].len() > 1{
+            if read_files[j].len() > 1 {
                 log::info!("Finished paired sample {}.", &read_files[j][0]);
-            }
-            else{
+            } else {
                 log::info!("Finished sample {}.", &read_files[j][0]);
             }
         });
@@ -362,79 +444,114 @@ pub fn contain(mut args: ContainArgs, pseudotax_in: bool) {
     log::info!("sylph finished.");
 }
 
-fn derep_if_reassign_threshold<'a>(results_old: &Vec<AniResult>, results_new: Vec<AniResult<'a>>, ani_thresh: f64, k: usize) -> Vec<AniResult<'a>>{
-    let ani_thresh = ani_thresh/100.;
+fn derep_if_reassign_threshold<'a>(
+    results_old: &Vec<AniResult>,
+    results_new: Vec<AniResult<'a>>,
+    ani_thresh: f64,
+    k: usize,
+) -> Vec<AniResult<'a>> {
+    let ani_thresh = ani_thresh / 100.;
 
     let mut gn_sketch_to_contain = FxHashMap::default();
-    for result in results_old.iter(){
+    for result in results_old.iter() {
         gn_sketch_to_contain.insert(result.genome_sketch, result);
     }
 
     let threshold = f64::powf(ani_thresh, k as f64);
     let mut return_vec = vec![];
-    for result in results_new.into_iter(){
+    for result in results_new.into_iter() {
         let old_res = &gn_sketch_to_contain[result.genome_sketch];
         let num_kmer_reassign = (old_res.containment_index.0 - result.containment_index.0) as f64;
         let reass_thresh = threshold * result.containment_index.1 as f64;
-        if num_kmer_reassign < reass_thresh{
+        if num_kmer_reassign < reass_thresh {
             return_vec.push(result);
-        }
-        else{
-            log::debug!("genome {} had num k-mers reassigned = {}, threshold was {}, removing.", result.gn_name, num_kmer_reassign, reass_thresh);
+        } else {
+            log::debug!(
+                "genome {} had num k-mers reassigned = {}, threshold was {}, removing.",
+                result.gn_name,
+                num_kmer_reassign,
+                reass_thresh
+            );
         }
     }
-    return return_vec;
+    return_vec
 }
 
-fn estimate_true_cov(results: &mut Vec<AniResult>, kmer_id_opt: Option<f64>, 
-                     estimate_unknown: bool, read_length: f64, k: usize){
+fn estimate_true_cov(
+    results: &mut Vec<AniResult>,
+    kmer_id_opt: Option<f64>,
+    estimate_unknown: bool,
+    read_length: f64,
+    k: usize,
+) {
     let mut multiplier = 1.;
-    if estimate_unknown{
+    if estimate_unknown {
         multiplier = read_length / (read_length - k as f64 + 1.);
     }
-    if estimate_unknown && kmer_id_opt.is_some(){
+    if estimate_unknown && kmer_id_opt.is_some() {
         let id = kmer_id_opt.unwrap();
-        for res in results.iter_mut(){
-            res.final_est_cov = res.final_est_cov / id * multiplier ;
+        for res in results.iter_mut() {
+            res.final_est_cov = res.final_est_cov / id * multiplier;
         }
     }
 }
 
-fn estimate_covered_bases(results: &Vec<AniResult>, sequence_sketch: &SequencesSketch, read_length: f64, k: usize) -> f64{
+fn estimate_covered_bases(
+    results: &Vec<AniResult>,
+    sequence_sketch: &SequencesSketch,
+    read_length: f64,
+    k: usize,
+) -> f64 {
     let multiplier = read_length / (read_length - (k as f64) + 1.);
 
     let mut num_covered_bases = 0.;
-    for res in results.iter(){
+    for res in results.iter() {
         num_covered_bases += (res.genome_sketch.gn_size as f64) * res.final_est_cov
     }
     let mut num_total_counts = 0;
-    for count in sequence_sketch.kmer_counts.values(){
+    for count in sequence_sketch.kmer_counts.values() {
         num_total_counts += *count as usize;
     }
     let num_tentative_bases = sequence_sketch.c * num_total_counts;
     let num_tentative_bases = num_tentative_bases as f64 * multiplier;
-    if num_tentative_bases == 0.{
+    if num_tentative_bases == 0. {
         return 0.;
     }
-    return f64::min(num_covered_bases as f64 / num_tentative_bases, 1.);
+    f64::min(num_covered_bases / num_tentative_bases, 1.)
 }
 
-fn winner_table<'a>(results : &'a Vec<AniResult>, log_reassign: bool) -> FxHashMap<Kmer, (f64,&'a GenomeSketch, bool)> {
-    let mut kmer_to_genome_map : FxHashMap<_,_> = FxHashMap::default();
-    for res in results.iter(){
+fn winner_table<'a>(
+    results: &'a Vec<AniResult>,
+    log_reassign: bool,
+) -> FxHashMap<Kmer, (f64, &'a GenomeSketch, bool)> {
+    let mut kmer_to_genome_map: FxHashMap<_, _> = FxHashMap::default();
+    for res in results.iter() {
         //let gn_sketch = &genome_sketches[res.genome_sketch_index];
         let gn_sketch = res.genome_sketch;
-        for kmer in gn_sketch.genome_kmers.iter(){
-            let v = kmer_to_genome_map.entry(*kmer).or_insert((res.final_est_ani, res.genome_sketch, false));
-            if res.final_est_ani > v.0{
+        for kmer in gn_sketch.genome_kmers.iter() {
+            let v = kmer_to_genome_map.entry(*kmer).or_insert((
+                res.final_est_ani,
+                res.genome_sketch,
+                false,
+            ));
+            if res.final_est_ani > v.0 {
                 *v = (res.final_est_ani, gn_sketch, true);
             }
         }
-        
-        if gn_sketch.pseudotax_tracked_nonused_kmers.is_some(){
-            for kmer in gn_sketch.pseudotax_tracked_nonused_kmers.as_ref().unwrap().iter(){
-                let v = kmer_to_genome_map.entry(*kmer).or_insert((res.final_est_ani, res.genome_sketch, false));
-                if res.final_est_ani > v.0{
+
+        if gn_sketch.pseudotax_tracked_nonused_kmers.is_some() {
+            for kmer in gn_sketch
+                .pseudotax_tracked_nonused_kmers
+                .as_ref()
+                .unwrap()
+                .iter()
+            {
+                let v = kmer_to_genome_map.entry(*kmer).or_insert((
+                    res.final_est_ani,
+                    res.genome_sketch,
+                    false,
+                ));
+                if res.final_est_ani > v.0 {
                     *v = (res.final_est_ani, gn_sketch, true);
                 }
             }
@@ -442,47 +559,52 @@ fn winner_table<'a>(results : &'a Vec<AniResult>, log_reassign: bool) -> FxHashM
     }
 
     //log reassigned kmers
-    if log_reassign{
+    if log_reassign {
         log::info!("------------- Logging k-mer reassignments -----------------");
         let mut sketch_to_index = FxHashMap::default();
-        for (i,res) in results.iter().enumerate(){
-            log::info!("Index\t{}\t{}\t{}", i, res.genome_sketch.file_name, res.genome_sketch.first_contig_name);
+        for (i, res) in results.iter().enumerate() {
+            log::info!(
+                "Index\t{}\t{}\t{}",
+                i,
+                res.genome_sketch.file_name,
+                res.genome_sketch.first_contig_name
+            );
             sketch_to_index.insert(res.genome_sketch, i);
         }
-        (0..results.len()).into_par_iter().for_each(|i|{
+        (0..results.len()).into_par_iter().for_each(|i| {
             let res = &results[i];
             let mut reassign_edge_map = FxHashMap::default();
-            for kmer in res.genome_sketch.genome_kmers.iter(){
+            for kmer in res.genome_sketch.genome_kmers.iter() {
                 let value = kmer_to_genome_map[kmer].1;
-                if value != res.genome_sketch{
-                    let edge_count = reassign_edge_map.entry((sketch_to_index[value],i)).or_insert(0);
+                if value != res.genome_sketch {
+                    let edge_count = reassign_edge_map
+                        .entry((sketch_to_index[value], i))
+                        .or_insert(0);
                     *edge_count += 1;
                 }
             }
-            for (key,val) in reassign_edge_map{
-                if val > 10{
+            for (key, val) in reassign_edge_map {
+                if val > 10 {
                     log::info!("{}->{}\t{}\tkmers reassigned", key.0, key.1, val);
                 }
             }
         });
     }
 
-    return kmer_to_genome_map;
+    kmer_to_genome_map
 }
 
 fn print_header(pseudotax: bool, writer: &mut Box<dyn Write + Send>, estimate_unknown: bool) {
-    if !pseudotax{
+    if !pseudotax {
         writeln!(writer,
             //"Sample_file\tQuery_file\tAdjusted_ANI\tNaive_ANI\tANI_5-95_percentile\tEff_cov\tEff_lambda\tLambda_5-95_percentile\tMedian_cov\tMean_cov_geq1\tContainment_ind\tContig_name",
             "Sample_file\tGenome_file\tAdjusted_ANI\tEff_cov\tANI_5-95_percentile\tEff_lambda\tLambda_5-95_percentile\tMedian_cov\tMean_cov_geq1\tContainment_ind\tNaive_ANI\tContig_name",
             ).expect("Error writing to file.");
-    }
-    else{
+    } else {
         let cov_head;
-        if estimate_unknown{
+        if estimate_unknown {
             cov_head = "True_cov";
-        }
-        else{
+        } else {
             cov_head = "Eff_cov";
         }
         writeln!(writer,
@@ -502,13 +624,12 @@ fn get_genome_sketches(
     let genome_sketches = Mutex::new(vec![]);
 
     for genome_sketch_file in genome_sketch_files {
-        let file = File::open(genome_sketch_file).expect(&format!("The sketch `{}` could not be opened. Exiting", genome_sketch_file));
+        let file = File::open(genome_sketch_file).unwrap_or_else(|_| panic!("The sketch `{}` could not be opened. Exiting",
+            genome_sketch_file));
         let genome_reader = BufReader::with_capacity(10_000_000, file);
         let genome_sketches_vec: Vec<GenomeSketch> = bincode::deserialize_from(genome_reader)
-            .expect(&format!(
-                "The sketch `{}` is not a valid sketch. Perhaps it is an older, incompatible version ",
-                &genome_sketch_file
-            ));
+            .unwrap_or_else(|_| panic!("The sketch `{}` is not a valid sketch. Perhaps it is an older, incompatible version ",
+            &genome_sketch_file));
         if genome_sketches_vec.is_empty() {
             continue;
         }
@@ -542,7 +663,7 @@ fn get_genome_sketches(
 
             }
             else{
-                let genome_sketch_opt = sketch_genome(args.c, args.k, &genome_file, args.min_spacing_kmer, args.pseudotax);
+                let genome_sketch_opt = sketch_genome(args.c, args.k, genome_file, args.min_spacing_kmer, args.pseudotax);
                 if genome_sketch_opt.is_some() {
                     genome_sketches.lock().unwrap().push(genome_sketch_opt.unwrap());
                 }
@@ -550,7 +671,7 @@ fn get_genome_sketches(
         }
     });
 
-    return genome_sketches.into_inner().unwrap();
+    genome_sketches.into_inner().unwrap()
 }
 
 fn get_seq_sketch(
@@ -563,48 +684,52 @@ fn get_seq_sketch(
     if is_sketch_file {
         let read_file = read_file[0];
         let read_sketch_file = read_file;
-        let file = File::open(read_sketch_file).expect(&format!(
-            "The sketch `{}` could not be opened",
-            &read_sketch_file
-        ));
+        let file = File::open(read_sketch_file).unwrap_or_else(|_| panic!("The sketch `{}` could not be opened",
+            &read_sketch_file));
         let read_reader = BufReader::with_capacity(10_000_000, file);
-        let read_sketch: SequencesSketch = bincode::deserialize_from(read_reader).expect(
-            &format!("The sketch `{}` is not a valid sketch. Perhaps it is an older incompatible version ", read_sketch_file),
-        );
+        let read_sketch: SequencesSketch = bincode::deserialize_from(read_reader).unwrap_or_else(|_| panic!("The sketch `{}` is not a valid sketch. Perhaps it is an older incompatible version ",
+            read_sketch_file));
         if read_sketch.c > genome_c {
             error!("{} value of -c is {}; this is greater than the smallest value of -c = {} for a genome sketch. Exiting.", read_file, read_sketch.c, genome_c);
             return None;
-        }
-        else if read_sketch.c < genome_c{
+        } else if read_sketch.c < genome_c {
             info!("{} value of -c for reads is {}; this is smaller than the -c for a genome sketch. Using the larger -c {} instead.", read_file, read_sketch.c,  genome_c);
         }
 
-        return Some(read_sketch);
+        Some(read_sketch)
     } else {
-        if args.c > genome_c{
+        if args.c > genome_c {
             info!("{} value of -c for reads is {}; this is smaller than the -c for a genome sketch. Using the larger -c {} instead.", read_file[0], args.c,  genome_c);
         }
         if genome_c < args.c {
             error!("{} error: value of -c for contain = {} -- greater than the smallest value of -c for a genome sketch = {}. Continuing without sketching.", read_file[0], args.c, genome_c);
-            return None;
-        } 
-        else if genome_k != args.k {
+            None
+        } else if genome_k != args.k {
             error!(
                 "{} -k {} is not equal to -k {} found in sketches. Continuing without sketching.",
                 read_file[0], args.k, genome_k
             );
-            return None;
+            None
         } else {
-            if read_file.len() == 1{
-                let read_sketch_opt = sketch_sequences_needle(&read_file[0], args.c, args.k, None, false);
-                return read_sketch_opt;
-            }
-            else if read_file.len() == 2{
-                let read_sketch_opt = sketch_pair_sequences(&read_file[0], &read_file[1], args.c, args.k, None, false, DEFAULT_FPR);
-                return read_sketch_opt;
-            }
-            else{
-                panic!("Internal Error: read_file has length {}. Something went wrong...", read_file.len());
+            if read_file.len() == 1 {
+                
+                sketch_sequences_needle(read_file[0], args.c, args.k, None, false)
+            } else if read_file.len() == 2 {
+                
+                sketch_pair_sequences(
+                    read_file[0],
+                    read_file[1],
+                    args.c,
+                    args.k,
+                    None,
+                    false,
+                    DEFAULT_FPR,
+                )
+            } else {
+                panic!(
+                    "Internal Error: read_file has length {}. Something went wrong...",
+                    read_file.len()
+                );
             }
         }
     }
@@ -614,8 +739,8 @@ fn get_stats<'a>(
     args: &ContainArgs,
     genome_sketch: &'a GenomeSketch,
     sequence_sketch: &SequencesSketch,
-    winner_map: Option<&FxHashMap<Kmer, (f64,& GenomeSketch, bool)>>,
-    log_reassign: bool
+    winner_map: Option<&FxHashMap<Kmer, (f64, &GenomeSketch, bool)>>,
+    log_reassign: bool,
 ) -> Option<AniResult<'a>> {
     if genome_sketch.k != sequence_sketch.k {
         log::error!(
@@ -636,27 +761,25 @@ fn get_stats<'a>(
     let mut contain_count = 0;
     let mut covs = vec![];
     let gn_kmers = &genome_sketch.genome_kmers;
-    if (gn_kmers.len() as f64) < args.min_number_kmers{
-        return None
+    if (gn_kmers.len() as f64) < args.min_number_kmers {
+        return None;
     }
 
     let mut kmers_lost_count = 0;
     for kmer in gn_kmers.iter() {
         if sequence_sketch.kmer_counts.contains_key(kmer) {
-            if sequence_sketch.kmer_counts[kmer] == 0{
-                continue
+            if sequence_sketch.kmer_counts[kmer] == 0 {
+                continue;
             }
-            if winner_map.is_some(){
+            if winner_map.is_some() {
                 let map = &winner_map.unwrap();
-                if map[kmer].1 != genome_sketch{
+                if map[kmer].1 != genome_sketch {
                     kmers_lost_count += 1;
-                    continue
+                    continue;
                 }
                 contain_count += 1;
                 covs.push(sequence_sketch.kmer_counts[kmer]);
-
-            }
-            else{
+            } else {
                 contain_count += 1;
                 covs.push(sequence_sketch.kmer_counts[kmer]);
             }
@@ -675,8 +798,8 @@ fn get_stats<'a>(
     let median_cov = covs[covs.len() / 2] as f64;
     let pois = Poisson::new(median_cov).unwrap();
     let mut max_cov = f64::MAX;
-    if median_cov < 30.{
-        for i in covs.len() / 2..covs.len(){
+    if median_cov < 30. {
+        for i in covs.len() / 2..covs.len() {
             let cov = covs[i];
             if pois.cdf(cov.into()) < CUTOFF_PVALUE {
                 max_cov = cov as f64;
@@ -685,8 +808,13 @@ fn get_stats<'a>(
             }
         }
     }
-    log::trace!("COV VECTOR for {}/{}: {:?}, MAX_COV_THRESHOLD: {}", sequence_sketch.file_name, genome_sketch.file_name ,covs, max_cov);
-
+    log::trace!(
+        "COV VECTOR for {}/{}: {:?}, MAX_COV_THRESHOLD: {}",
+        sequence_sketch.file_name,
+        genome_sketch.file_name,
+        covs,
+        max_cov
+    );
 
     let mut full_covs = vec![0; gn_kmers.len() - contain_count];
     for cov in covs.iter() {
@@ -695,7 +823,7 @@ fn get_stats<'a>(
         }
     }
     let var = var(&full_covs);
-    if var.is_some(){
+    if var.is_some() {
         log::trace!("VAR {} {}", var.unwrap(), genome_sketch.file_name);
     }
     let mean_cov = full_covs.iter().sum::<u32>() as f64 / full_covs.len() as f64;
@@ -728,13 +856,12 @@ fn get_stats<'a>(
 
     if let AdjustStatus::Lambda(lam) = use_lambda {
         final_est_cov = lam
-    } else if median_cov < MAX_MEDIAN_FOR_MEAN_FINAL_EST{
+    } else if median_cov < MAX_MEDIAN_FOR_MEAN_FINAL_EST {
         final_est_cov = geq1_mean_cov;
-    } else{
-        if args.mean_coverage{
+    } else {
+        if args.mean_coverage {
             final_est_cov = geq1_mean_cov;
-        }
-        else{
+        } else {
             final_est_cov = median_cov;
         }
     }
@@ -747,7 +874,7 @@ fn get_stats<'a>(
     };
 
     let opt_est_ani = ani_from_lambda(opt_lambda, mean_cov, sequence_sketch.k as f64, &full_covs);
-    
+
     let final_est_ani;
     if opt_lambda.is_none() || opt_est_ani.is_none() || args.no_adj {
         final_est_ani = naive_ani;
@@ -755,13 +882,17 @@ fn get_stats<'a>(
         final_est_ani = opt_est_ani.unwrap();
     }
 
-    let min_ani = if args.minimum_ani.is_some() {args.minimum_ani.unwrap()/100. }
-        else if args.pseudotax { MIN_ANI_P_DEF } 
-        else { MIN_ANI_DEF };
+    let min_ani = if args.minimum_ani.is_some() {
+        args.minimum_ani.unwrap() / 100.
+    } else if args.pseudotax {
+        MIN_ANI_P_DEF
+    } else {
+        MIN_ANI_DEF
+    };
     if final_est_ani < min_ani {
-        if winner_map.is_some(){
+        if winner_map.is_some() {
             //Used to be > min ani, now it is not after reassignment
-            if log_reassign{
+            if log_reassign {
                 log::info!("Genome/contig {}/{} has ANI = {} < {} after reassigning {} k-mers ({} contained k-mers after reassign)", 
                     genome_sketch.file_name,
                     genome_sketch.first_contig_name,
@@ -770,34 +901,30 @@ fn get_stats<'a>(
                     kmers_lost_count,
                     contain_count)
             }
-
         }
         return None;
     }
 
     let (mut low_ani, mut high_ani, mut low_lambda, mut high_lambda) = (None, None, None, None);
     if !args.no_ci && opt_lambda.is_some() {
-        let bootstrap = bootstrap_interval(&full_covs, sequence_sketch.k as f64, &args);
+        let bootstrap = bootstrap_interval(&full_covs, sequence_sketch.k as f64, args);
         low_ani = bootstrap.0;
         high_ani = bootstrap.1;
         low_lambda = bootstrap.2;
         high_lambda = bootstrap.3;
     }
 
-    
     let seq_name;
-    if let Some(sample) = &sequence_sketch.sample_name{
+    if let Some(sample) = &sequence_sketch.sample_name {
         seq_name = sample.clone();
-    }
-    else{
+    } else {
         seq_name = sequence_sketch.file_name.clone();
     }
 
     let kmers_lost;
-    if winner_map.is_some(){
+    if winner_map.is_some() {
         kmers_lost = Some(kmers_lost_count)
-    }
-    else{
+    } else {
         kmers_lost = None;
     }
 
@@ -805,7 +932,7 @@ fn get_stats<'a>(
         naive_ani,
         final_est_ani,
         final_est_cov,
-        seq_name: seq_name,
+        seq_name,
         gn_name: genome_sketch.file_name.as_str(),
         contig_name: genome_sketch.first_contig_name.as_str(),
         mean_cov: geq1_mean_cov,
@@ -814,22 +941,18 @@ fn get_stats<'a>(
         lambda: use_lambda,
         ani_ci: (low_ani, high_ani),
         lambda_ci: (low_lambda, high_lambda),
-        genome_sketch: genome_sketch,
+        genome_sketch,
         rel_abund: None,
         seq_abund: None,
-        kmers_lost: kmers_lost,
-
+        kmers_lost,
     };
     //log::trace!("Other time {:?}", Instant::now() - start_t_initial);
 
-    return Some(ani_result);
+    Some(ani_result)
 }
 
-
 fn ani_from_lambda(lambda: Option<f64>, _mean: f64, k: f64, full_cov: &[u32]) -> Option<f64> {
-    if lambda.is_none() {
-        return None;
-    }
+    lambda?;
     let mut contain_count = 0;
     let mut _zero_count = 0;
     for x in full_cov {
@@ -841,8 +964,7 @@ fn ani_from_lambda(lambda: Option<f64>, _mean: f64, k: f64, full_cov: &[u32]) ->
     }
 
     let lambda = lambda.unwrap();
-    let adj_index =
-        contain_count as f64 / (1. - f64::exp(-lambda)) / full_cov.len() as f64;
+    let adj_index = contain_count as f64 / (1. - f64::exp(-lambda)) / full_cov.len() as f64;
     let ret_ani;
     //let ani = f64::powf(1. - pi, 1./k);
     let ani = f64::powf(adj_index, 1. / k);
@@ -855,7 +977,7 @@ fn ani_from_lambda(lambda: Option<f64>, _mean: f64, k: f64, full_cov: &[u32]) ->
             ret_ani = Some(ani);
         }
     }
-    return ret_ani;
+    ret_ani
 }
 
 fn bootstrap_interval(
@@ -885,15 +1007,14 @@ fn bootstrap_interval(
         } else if args.mle {
             lambda = mle_zip(&rand_vec, k);
         } else {
-            lambda = ratio_lambda(&rand_vec,args.min_count_correct);
+            lambda = ratio_lambda(&rand_vec, args.min_count_correct);
         }
-        let ani = ani_from_lambda(lambda, mean(&rand_vec).unwrap().into(), k, &rand_vec);
-        if ani.is_some() && lambda.is_some() {
-            if !ani.unwrap().is_nan() && !lambda.unwrap().is_nan() {
+        let ani = ani_from_lambda(lambda, mean(&rand_vec).unwrap(), k, &rand_vec);
+        if ani.is_some() && lambda.is_some()
+            && !ani.unwrap().is_nan() && !lambda.unwrap().is_nan() {
                 res_ani.push(ani);
                 res_lambda.push(lambda);
             }
-        }
     }
     res_ani.sort_by(|x, y| x.partial_cmp(y).unwrap());
     res_lambda.sort_by(|x, y| x.partial_cmp(y).unwrap());
@@ -906,25 +1027,22 @@ fn bootstrap_interval(
     let low_lambda = res_lambda[suc * 5 / 100 - 1];
     let high_lambda = res_lambda[suc * 95 / 100 - 1];
 
-    return (low_ani, high_ani, low_lambda, high_lambda);
+    (low_ani, high_ani, low_lambda, high_lambda)
 }
 
-
-fn get_kmer_identity(seq_sketch: &SequencesSketch, estimate_unknown: bool) -> Option<f64>{
-
-    if !estimate_unknown{
-        return None
+fn get_kmer_identity(seq_sketch: &SequencesSketch, estimate_unknown: bool) -> Option<f64> {
+    if !estimate_unknown {
+        return None;
     }
 
     let mut median = 0;
     let mut mov_avg_median = 0.;
     let mut n = 1.;
-    for count in seq_sketch.kmer_counts.values(){
-        if *count > 1{
-            if *count > median{
+    for count in seq_sketch.kmer_counts.values() {
+        if *count > 1 {
+            if *count > median {
                 median += 1;
-            }
-            else{
+            } else {
                 median -= 1;
             }
             mov_avg_median += median as f64;
@@ -933,15 +1051,18 @@ fn get_kmer_identity(seq_sketch: &SequencesSketch, estimate_unknown: bool) -> Op
     }
 
     mov_avg_median /= n;
-    log::debug!("Estimated continuous median k-mer count for {} is {:.3}", &seq_sketch.file_name, mov_avg_median);
-    
+    log::debug!(
+        "Estimated continuous median k-mer count for {} is {:.3}",
+        &seq_sketch.file_name,
+        mov_avg_median
+    );
+
     let mut num_1s = 0;
     let mut num_not1s = 0;
-    for count in seq_sketch.kmer_counts.values(){
-        if *count == 1{
+    for count in seq_sketch.kmer_counts.values() {
+        if *count == 1 {
             num_1s += 1;
-        }
-        else{
+        } else {
             num_not1s += *count;
         }
     }
@@ -949,15 +1070,14 @@ fn get_kmer_identity(seq_sketch: &SequencesSketch, estimate_unknown: bool) -> Op
     let eps = num_not1s as f64 / (num_not1s as f64 + num_1s as f64 + 0.1);
     //dbg!("Automatic id est, 1-to-2 ratio, 2-to-3", eps.powf(1./31.), num_1s as f64 / num_2s as f64, two_to_three);
 
-    if mov_avg_median < MED_KMER_FOR_ID_EST && seq_sketch.mean_read_length < 400.{
+    if mov_avg_median < MED_KMER_FOR_ID_EST && seq_sketch.mean_read_length < 400. {
         log::info!("{} short-read sample has high diversity compared to sequencing depth (approx. avg depth < 3). Using 99.5% as read accuracy estimate instead of automatic detection for --estimate-unknown.", &seq_sketch.file_name);
         return Some(0.995f64.powf(seq_sketch.k as f64));
     }
 
-    if eps < 1.{
-        return Some(eps)
-    }
-    else{
-        return Some(1.)
+    if eps < 1. {
+        Some(eps)
+    } else {
+        Some(1.)
     }
 }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,34 +1,33 @@
-use statrs::function::gamma::*;
-use fxhash::FxHashMap;
 use crate::constants::*;
+use fxhash::FxHashMap;
+use statrs::function::gamma::*;
 use std::collections::HashSet;
 
-pub fn r_from_moments_lambda(m: f64, v: f64, lambda: f64) -> f64{
+pub fn r_from_moments_lambda(m: f64, v: f64, lambda: f64) -> f64 {
     //return (v / m - 1. - lambda + m) / lambda;
     //return 1000.;
-    return lambda / (v - 1. + lambda + m)
+    lambda / (v - 1. + lambda + m)
 }
 
-pub fn ratio_formula(val: f64, r: f64, lambda: f64) -> f64{
-    if r < 100.{
-       return gamma(r + val + 1.) / (val + 1.) / gamma(r + val) * lambda / (r + lambda)
-    }
-    else{
-       return (r + val + 1.) / (val + 1.) * lambda / (r + lambda)
+pub fn ratio_formula(val: f64, r: f64, lambda: f64) -> f64 {
+    if r < 100. {
+        gamma(r + val + 1.) / (val + 1.) / gamma(r + val) * lambda / (r + lambda)
+    } else {
+        (r + val + 1.) / (val + 1.) * lambda / (r + lambda)
     }
 }
 
-fn ratio_from_moments_lambda(val: f64, lambda: f64, m: f64, v: f64) -> Option<f64>{
+fn ratio_from_moments_lambda(val: f64, lambda: f64, m: f64, v: f64) -> Option<f64> {
     let r = r_from_moments_lambda(m, v, lambda);
-    if r < 0.{
+    if r < 0. {
         return None;
     }
-    return Some(ratio_formula(val, r, lambda));
+    Some(ratio_formula(val, r, lambda))
 }
 
-pub fn binary_search_lambda(full_covs: &[u32]) -> Option<f64>{
-    if full_covs.len() == 0{
-        return None
+pub fn binary_search_lambda(full_covs: &[u32]) -> Option<f64> {
+    if full_covs.is_empty() {
+        return None;
     }
     let m = mean(full_covs).unwrap();
     let v = var(full_covs).unwrap();
@@ -36,81 +35,76 @@ pub fn binary_search_lambda(full_covs: &[u32]) -> Option<f64>{
     let mut ones = 0;
     let mut twos = 0;
 
-    for x in full_covs{
-        if *x != 0{
+    for x in full_covs {
+        if *x != 0 {
             _nonzero += 1;
         }
-        if *x == 1{
+        if *x == 1 {
             ones += 1;
-        }
-        else if *x == 2{
+        } else if *x == 2 {
             twos += 1;
         }
     }
-
-
 
     let ratio_est = twos as f64 / ones as f64;
 
     let left = f64::max(0.003, m - 2.);
     let right = m + 5.;
-    let endpoints = (left,right);
+    let endpoints = (left, right);
     let mut best = None;
     let mut best_val = 10000.;
-    for i in 0..10000{
-        let test = (endpoints.1 - endpoints.0)/10000. * i as f64 + endpoints.0;
-        let proposed = ratio_from_moments_lambda(1.,test , m, v);
-        if proposed.is_some(){
+    for i in 0..10000 {
+        let test = (endpoints.1 - endpoints.0) / 10000. * i as f64 + endpoints.0;
+        let proposed = ratio_from_moments_lambda(1., test, m, v);
+        if proposed.is_some() {
             let p = proposed.unwrap() - ratio_est;
-            if p.abs() < best_val{
+            if p.abs() < best_val {
                 best_val = p.abs();
                 best = Some(test);
             }
         }
     }
-    if best.is_none(){
-        return None
-    }
+    best?;
     let best = best.unwrap();
-    let r = r_from_moments_lambda(m,v,best);
-    dbg!(m,v, ratio_est, r, best);
-//    let ratio_adj = 1. - pi;
-//    dbg!(best,best_val, r, nonzero, full_covs.len(), f64::powf(nonzero as f64 / full_covs.len() as f64, 1./k));
-//    dbg!(1. - m / best, f64::powf(1. - m/best, 1. / k as f64));
-//    dbg!(zeros_from_nb, ratio_adj, f64::powf(ratio_adj, 1. / k));
-//    let val = 1.;
-//    let mut endpoints_output = (ratio_from_moments_lambda(1., endpoints.0, m, v) - ratio_est, ratio_from_moments_lambda(1., endpoints.1, m, v) - ratio_est);
-//    if endpoints_output.0 < 0. || endpoints_output.1 > 0.{
-//        return None;
-//    }
-//    dbg!(endpoints_output);
-//    for _ in 0..100{
-//        let proposed = ratio_from_moments_lambda(1., (endpoints.1 + endpoints.0)/2., m, v) - ratio_est;
-//        if proposed > 0.{
-//            endpoints.0 = (endpoints.1 + endpoints.0)/2.;
-//            endpoints_output.0 = proposed;
-//        }
-//        else{
-//            endpoints.1 = (endpoints.1 + endpoints.0)/2.;
-//            endpoints_output.1 = proposed;
-//        }
-//        curr = endpoints_output.0;
-//        dbg!(endpoints, endpoints_output, proposed);
-//    }
-//
-    return Some(best);
+    let r = r_from_moments_lambda(m, v, best);
+    dbg!(m, v, ratio_est, r, best);
+    //    let ratio_adj = 1. - pi;
+    //    dbg!(best,best_val, r, nonzero, full_covs.len(), f64::powf(nonzero as f64 / full_covs.len() as f64, 1./k));
+    //    dbg!(1. - m / best, f64::powf(1. - m/best, 1. / k as f64));
+    //    dbg!(zeros_from_nb, ratio_adj, f64::powf(ratio_adj, 1. / k));
+    //    let val = 1.;
+    //    let mut endpoints_output = (ratio_from_moments_lambda(1., endpoints.0, m, v) - ratio_est, ratio_from_moments_lambda(1., endpoints.1, m, v) - ratio_est);
+    //    if endpoints_output.0 < 0. || endpoints_output.1 > 0.{
+    //        return None;
+    //    }
+    //    dbg!(endpoints_output);
+    //    for _ in 0..100{
+    //        let proposed = ratio_from_moments_lambda(1., (endpoints.1 + endpoints.0)/2., m, v) - ratio_est;
+    //        if proposed > 0.{
+    //            endpoints.0 = (endpoints.1 + endpoints.0)/2.;
+    //            endpoints_output.0 = proposed;
+    //        }
+    //        else{
+    //            endpoints.1 = (endpoints.1 + endpoints.0)/2.;
+    //            endpoints_output.1 = proposed;
+    //        }
+    //        curr = endpoints_output.0;
+    //        dbg!(endpoints, endpoints_output, proposed);
+    //    }
+    //
+    Some(best)
 }
 
 pub fn var(data: &[u32]) -> Option<f64> {
-    if data.is_empty(){
-        return None
+    if data.is_empty() {
+        return None;
     }
     let mean = mean(data).unwrap();
     let mut var = 0.;
-    for x in data{
+    for x in data {
         var += (*x as f64 - mean) * (*x as f64 - mean)
     }
-    return Some(var / data.len() as f64);
+    Some(var / data.len() as f64)
 }
 
 pub fn mean(data: &[u32]) -> Option<f64> {
@@ -144,13 +138,13 @@ pub fn mme_lambda(full_covs: &[u32]) -> Option<f64> {
         return None;
     }
 
-    let mean = mean(&full_covs).unwrap();
-    let var = var(&full_covs).unwrap();
+    let mean = mean(full_covs).unwrap();
+    let var = var(full_covs).unwrap();
     let lambda = var / mean + mean - 1.;
     if lambda < 0. {
-        return None;
+        None
     } else {
-        return Some(lambda as f64);
+        Some(lambda)
     }
 }
 
@@ -175,10 +169,10 @@ pub fn mle_zip(full_covs: &[u32], _k: f64) -> Option<f64> {
         return None;
     }
 
-    let mean = mean(&full_covs).unwrap();
+    let mean = mean(full_covs).unwrap();
     let lambda = newton_raphson(
         (num_zero as f32 / full_covs.len() as f32).into(),
-        mean.into(),
+        mean,
     );
     //    log::trace!("lambda,pi {} {} {}", lambda,pi, num_zero as f64 / full_covs.len() as f64);
     let ret_lambda;
@@ -188,7 +182,7 @@ pub fn mle_zip(full_covs: &[u32], _k: f64) -> Option<f64> {
         ret_lambda = Some(lambda);
     }
 
-    return ret_lambda;
+    ret_lambda
 }
 
 fn newton_raphson(rat: f64, mean: f64) -> f64 {
@@ -199,9 +193,9 @@ fn newton_raphson(rat: f64, mean: f64) -> f64 {
         let t2 = mean * (1. - f64::exp(-curr));
         let t3 = 1. - rat;
         let t4 = mean * (f64::exp(-curr));
-        curr = curr - (t1 - t2) / (t3 - t4);
+        curr -= (t1 - t2) / (t3 - t4);
     }
-    return curr;
+    curr
 }
 
 pub fn ratio_lambda(full_covs: &Vec<u32>, min_count_correct: f64) -> Option<f64> {
@@ -223,20 +217,20 @@ pub fn ratio_lambda(full_covs: &Vec<u32>, min_count_correct: f64) -> Option<f64>
     }
 
     if full_covs.len() - num_zero < SAMPLE_SIZE_CUTOFF {
-        return None;
+        None
     } else {
         let mut sort_vec: Vec<(_, _)> = count_map.iter().map(|x| (x.1, x.0)).collect();
-        sort_vec.sort_by(|x, y| y.cmp(&x));
+        sort_vec.sort_by(|x, y| y.cmp(x));
         let most_ind = sort_vec[0].1;
         if !count_map.contains_key(&(most_ind + 1)) {
             return None;
         }
         let count_p1 = count_map[&(most_ind + 1)] as f64;
-        let count = count_map[&most_ind] as f64;
-        if count_p1 < min_count_correct || count < min_count_correct{
+        let count = count_map[most_ind] as f64;
+        if count_p1 < min_count_correct || count < min_count_correct {
             return None;
         }
-        let lambda = Some(count_p1 / count * ((most_ind + 1) as f64));
-        return lambda;
+        
+        Some(count_p1 / count * ((most_ind + 1) as f64))
     }
 }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,23 +1,23 @@
+use crate::cmdline::*;
+use crate::constants::*;
 use crate::types::*;
+use log::*;
+use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::BufReader;
 use std::io::BufWriter;
 use std::io::Write;
-use log::*;
-use crate::constants::*;
-use crate::cmdline::*;
-use serde::{Deserialize, Serialize};
 
-fn pipe_write(text: &str, writer: &mut Box<dyn Write + Send>){
+fn pipe_write(text: &str, writer: &mut Box<dyn Write + Send>) {
     let result = write!(writer, "{}", text);
     match result {
-        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {},
-        _other => {},
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+        _other => {}
     }
 }
 
 #[derive(Default, Deserialize, Serialize, Debug, PartialEq)]
-struct SequencesSketchInspect{
+struct SequencesSketchInspect {
     pub file_name: String,
     pub c: usize,
     pub k: usize,
@@ -28,16 +28,17 @@ struct SequencesSketchInspect{
     pub paired: bool,
 }
 
-impl From<SequencesSketch> for SequencesSketchInspect{
-    fn from(
-        sk: SequencesSketch
-    ) -> Self {
-        SequencesSketchInspect{
+impl From<SequencesSketch> for SequencesSketchInspect {
+    fn from(sk: SequencesSketch) -> Self {
+        SequencesSketchInspect {
             file_name: sk.file_name,
             num_sketched_kmers: sk.kmer_counts.len(),
             c: sk.c,
             k: sk.k,
-            approximate_number_bases: (sk.mean_read_length + sk.k as f64 - 1.) as f32 / (sk.mean_read_length) as f32 * sk.c as f32 * sk.kmer_counts.len() as f32,
+            approximate_number_bases: (sk.mean_read_length + sk.k as f64 - 1.) as f32
+                / (sk.mean_read_length) as f32
+                * sk.c as f32
+                * sk.kmer_counts.len() as f32,
             sample_name: sk.sample_name,
             paired: sk.paired,
             mean_read_length: sk.mean_read_length,
@@ -46,7 +47,7 @@ impl From<SequencesSketch> for SequencesSketchInspect{
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Hash, PartialOrd, Eq, Ord, Default, Clone)]
-pub struct GenomeSketchInspect{
+pub struct GenomeSketchInspect {
     pub file_name: String,
     pub genome_kmers_num: usize,
     pub first_contig_name: String,
@@ -54,10 +55,8 @@ pub struct GenomeSketchInspect{
 }
 
 impl From<GenomeSketch> for GenomeSketchInspect {
-    fn from(
-        sk: GenomeSketch
-    ) -> Self {
-        GenomeSketchInspect{
+    fn from(sk: GenomeSketch) -> Self {
+        GenomeSketchInspect {
             genome_kmers_num: sk.genome_kmers.len(),
             file_name: sk.file_name,
             first_contig_name: sk.first_contig_name,
@@ -67,7 +66,7 @@ impl From<GenomeSketch> for GenomeSketchInspect {
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Hash, PartialOrd, Eq, Ord, Default, Clone)]
-pub struct DatabaseSketch{
+pub struct DatabaseSketch {
     pub database_file: String,
     pub c: usize,
     pub k: usize,
@@ -90,31 +89,31 @@ impl<'de> serde::de::Visitor<'de> for DatabaseVisitor {
     }
 
     fn visit_seq<S>(mut self, mut seq: S) -> Result<Self, S::Error>
-        where
-            S: serde::de::SeqAccess<'de>,
-        {
-            while let Some(value) = seq.next_element::<GenomeSketch>()? {
-                self.c.get_or_insert(value.c);
-                self.k.get_or_insert(value.k);
-                self.min_spacing.get_or_insert(value.min_spacing);
-                self.sketches.push(value.into());
-            }
-
-            Ok(self)
+    where
+        S: serde::de::SeqAccess<'de>,
+    {
+        while let Some(value) = seq.next_element::<GenomeSketch>()? {
+            self.c.get_or_insert(value.c);
+            self.k.get_or_insert(value.k);
+            self.min_spacing.get_or_insert(value.min_spacing);
+            self.sketches.push(value.into());
         }
+
+        Ok(self)
+    }
 }
 
 impl<'de> Deserialize<'de> for DatabaseVisitor {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: serde::de::Deserializer<'de>
+    where
+        D: serde::de::Deserializer<'de>,
     {
         let inspector = DatabaseVisitor::default();
         deserializer.deserialize_seq(inspector)
     }
 }
 
-
-pub fn inspect(args: InspectArgs){
+pub fn inspect(args: InspectArgs) {
     simple_logger::SimpleLogger::new()
         .with_level(log::LevelFilter::Info)
         .init()
@@ -123,76 +122,67 @@ pub fn inspect(args: InspectArgs){
     let mut read_sketch_files = Vec::new();
     let mut genome_sketch_files = Vec::new();
 
-    for file in args.files.iter(){
+    for file in args.files.iter() {
         let mut genome_sketch_good_suffix = false;
-        for suff in QUERY_FILE_SUFFIX_VALID{
-            if file.ends_with(suff){
+        for suff in QUERY_FILE_SUFFIX_VALID {
+            if file.ends_with(suff) {
                 genome_sketch_good_suffix = true;
-                break
+                break;
             }
         }
 
         let mut sample_sketch_good_suffix = false;
-        for suff in SAMPLE_FILE_SUFFIX_VALID{
-            if file.ends_with(suff){
+        for suff in SAMPLE_FILE_SUFFIX_VALID {
+            if file.ends_with(suff) {
                 sample_sketch_good_suffix = true;
-                break
+                break;
             }
         }
 
-        if genome_sketch_good_suffix{
+        if genome_sketch_good_suffix {
             genome_sketch_files.push(file);
-        } else if sample_sketch_good_suffix{
+        } else if sample_sketch_good_suffix {
             read_sketch_files.push(file);
         } else {
-            warn!(
-                "{} file is not a .sylsp or .syldb file. Skipping...",
-                &file
-            );
+            warn!("{} file is not a .sylsp or .syldb file. Skipping...", &file);
         }
     }
 
     let mut out_writer = match args.out_file_name {
-        Some(ref x) => {
-            Box::new(BufWriter::new(File::create(&x).unwrap())) as Box<dyn Write + Send>
-        }
+        Some(ref x) => Box::new(BufWriter::new(File::create(x).unwrap())) as Box<dyn Write + Send>,
         None => Box::new(BufWriter::new(std::io::stdout())) as Box<dyn Write + Send>,
     };
 
     let mut db_sketches_inspect = Vec::new();
-    for file in genome_sketch_files.iter(){
+    for file in genome_sketch_files.iter() {
         let db_sketch = get_db_sketch_inspect(file);
         db_sketches_inspect.push(db_sketch);
     }
     let yaml = serde_yaml::to_string(&db_sketches_inspect).unwrap();
-    if !db_sketches_inspect.is_empty(){
+    if !db_sketches_inspect.is_empty() {
         pipe_write(&yaml, &mut out_writer);
     }
 
     let mut seq_sketches_inspect = Vec::new();
 
-    for file in read_sketch_files.iter(){
+    for file in read_sketch_files.iter() {
         let seq_sketch = get_seq_sketch_inspect(file);
         seq_sketches_inspect.push(seq_sketch);
     }
     let yaml = serde_yaml::to_string(&seq_sketches_inspect).unwrap();
-    if !seq_sketches_inspect.is_empty(){
+    if !seq_sketches_inspect.is_empty() {
         pipe_write(&yaml, &mut out_writer);
     }
 }
 
-fn get_db_sketch_inspect(
-    genome_sketch_file: &String,
-)  -> DatabaseSketch{
-
-    let file = File::open(genome_sketch_file).expect(&format!("The sketch `{}` could not be opened. Exiting", genome_sketch_file));
+fn get_db_sketch_inspect(genome_sketch_file: &String) -> DatabaseSketch {
+    let file = File::open(genome_sketch_file).unwrap_or_else(|_| panic!("The sketch `{}` could not be opened. Exiting",
+        genome_sketch_file));
     let genome_reader = BufReader::with_capacity(10_000_000, file);
 
     let visitor: DatabaseVisitor = bincode::deserialize_from(genome_reader)
-        .expect(&format!(
-            "The database sketch `{}` is not a valid sketch. Perhaps it is an older, incompatible version ",
-            &genome_sketch_file
-        ));
+        .unwrap_or_else(|_| panic!("The database sketch `{}` is not a valid sketch. Perhaps it is an older, incompatible version ",
+            &genome_sketch_file));
     if visitor.sketches.is_empty() {
         warn!(
             "The database sketch `{}` is empty. Skipping...",
@@ -203,10 +193,11 @@ fn get_db_sketch_inspect(
 
     info!(
         "Database file {} processed with {} genomes",
-        genome_sketch_file, visitor.sketches.len()
+        genome_sketch_file,
+        visitor.sketches.len()
     );
 
-    DatabaseSketch{
+    DatabaseSketch {
         database_file: genome_sketch_file.clone(),
         c: visitor.c.unwrap(),
         k: visitor.k.unwrap(),
@@ -215,19 +206,13 @@ fn get_db_sketch_inspect(
     }
 }
 
-fn get_seq_sketch_inspect(
-    read_file: &String,
-) -> SequencesSketchInspect{
-    let file = File::open(read_file).expect(&format!("The sketch `{}` could not be opened. Exiting", read_file));
+fn get_seq_sketch_inspect(read_file: &String) -> SequencesSketchInspect {
+    let file = File::open(read_file).unwrap_or_else(|_| panic!("The sketch `{}` could not be opened. Exiting",
+        read_file));
     let seq_reader = BufReader::with_capacity(10_000_000, file);
     let seq_sketch: SequencesSketch = bincode::deserialize_from(seq_reader)
-        .expect(&format!(
-            "The sequence sketch `{}` is not a valid sketch. Perhaps it is an older, incompatible version ",
-            &read_file
-        ));
-    info!(
-        "Sequence file {} processed",
-        read_file,
-    );
+        .unwrap_or_else(|_| panic!("The sequence sketch `{}` is not a valid sketch. Perhaps it is an older, incompatible version ",
+            &read_file));
+    info!("Sequence file {} processed", read_file,);
     seq_sketch.into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,11 @@
-pub mod sketch;
-pub mod constants;
-pub mod types;
-pub mod seeding;
 pub mod cmdline;
+pub mod constants;
 pub mod contain;
 pub mod inference;
 pub mod inspect;
+pub mod seeding;
+pub mod sketch;
+pub mod types;
 
 #[cfg(target_arch = "x86_64")]
 pub mod avx2_seeding;
-
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use sylph::cmdline::*;
-use sylph::sketch;
 use sylph::contain;
 use sylph::inspect;
+use sylph::sketch;
 //use std::panic::set_hook;
 
 //Use this allocator when statically compiling
@@ -10,17 +10,17 @@ use sylph::inspect;
 //because the musl statically compiled binary
 //uses a bad default allocator which makes the
 //binary take 60% longer!!! Only affects
-//static compilation though. 
+//static compilation though.
 #[cfg(target_env = "musl")]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() {
-//    set_hook(Box::new(|info| {
-//        if let Some(s) = info.payload().downcast_ref::<String>() {
-//            log::error!("{}", s);
-//        }
-//    }));
+    //    set_hook(Box::new(|info| {
+    //        if let Some(s) = info.payload().downcast_ref::<String>() {
+    //            log::error!("{}", s);
+    //        }
+    //    }));
     let cli = Cli::parse();
     match cli.mode {
         Mode::Sketch(sketch_args) => sketch::sketch(sketch_args),

--- a/src/seeding.rs
+++ b/src/seeding.rs
@@ -24,7 +24,7 @@ pub fn rev_hash_64(hashed_key: u64) -> u64 {
 
     // Invert h_key = h_key ^ h_key >> 28;
     tmp = key ^ key >> 28;
-    key = key ^ tmp >> 28;
+    key ^= tmp >> 28;
 
     // Invert h_key = h_key.wrapping_add(h_key << 2).wrapping_add(h_key << 4)
     key = key.wrapping_mul(14933078535860113213u64);
@@ -33,14 +33,14 @@ pub fn rev_hash_64(hashed_key: u64) -> u64 {
     tmp = key ^ key >> 14;
     tmp = key ^ tmp >> 14;
     tmp = key ^ tmp >> 14;
-    key = key ^ tmp >> 14;
+    key ^= tmp >> 14;
 
     // Invert h_key = h_key.wrapping_add(h_key << 3).wrapping_add(h_key << 8)
     key = key.wrapping_mul(15244667743933553977u64);
 
     // Invert h_key = h_key ^ h_key >> 24
     tmp = key ^ key >> 24;
-    key = key ^ tmp >> 24;
+    key ^= tmp >> 24;
 
     // Invert h_key = (!h_key).wrapping_add(h_key << 21)
     tmp = !key;
@@ -53,13 +53,13 @@ pub fn rev_hash_64(hashed_key: u64) -> u64 {
 
 pub fn decode(byte: u64) -> u8 {
     if byte == 0 {
-        return b'A';
+        b'A'
     } else if byte == 1 {
-        return b'C';
+        b'C'
     } else if byte == 2 {
-        return b'G';
+        b'G'
     } else if byte == 3 {
-        return b'T';
+        b'T'
     } else {
         panic!("decoding failed")
     }
@@ -68,7 +68,7 @@ pub fn print_string(kmer: u64, k: usize) {
     let mut bytes = vec![];
     let mask = 3;
     for i in 0..k {
-        let val = kmer >> 2 * i;
+        let val = kmer >> (2 * i);
         let val = val & mask;
         bytes.push(decode(val));
     }
@@ -83,12 +83,7 @@ fn _position_min<T: Ord>(slice: &[T]) -> Option<usize> {
         .map(|(idx, _)| idx)
 }
 
-pub fn fmh_seeds(
-    string: &[u8],
-    kmer_vec: &mut Vec<u64>,
-    c: usize,
-    k: usize
-) {
+pub fn fmh_seeds(string: &[u8], kmer_vec: &mut Vec<u64>, c: usize, k: usize) {
     type MarkerBits = u64;
     if string.len() < k {
         return;
@@ -116,7 +111,7 @@ pub fn fmh_seeds(
         rolling_kmer_r_marker >>= 2;
         rolling_kmer_r_marker |= nuc_r << marker_reverse_shift_dist;
     }
-    for i in marker_k-1..len {
+    for i in marker_k - 1..len {
         let nuc_byte = string[i] as usize;
         let nuc_f = BYTE_TO_SEQ[nuc_byte] as u64;
         let nuc_r = 3 - nuc_f;
@@ -147,10 +142,10 @@ pub fn fmh_seeds(
 
 pub fn fmh_seeds_positions(
     string: &[u8],
-    kmer_vec: &mut Vec<(usize,usize,u64)>,
+    kmer_vec: &mut Vec<(usize, usize, u64)>,
     c: usize,
     k: usize,
-    contig_number: usize
+    contig_number: usize,
 ) {
     type MarkerBits = u64;
     if string.len() < k {
@@ -179,7 +174,7 @@ pub fn fmh_seeds_positions(
         rolling_kmer_r_marker >>= 2;
         rolling_kmer_r_marker |= nuc_r << marker_reverse_shift_dist;
     }
-    for i in marker_k-1..len {
+    for i in marker_k - 1..len {
         let nuc_byte = string[i] as usize;
         let nuc_f = BYTE_TO_SEQ[nuc_byte] as u64;
         let nuc_r = 3 - nuc_f;

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -26,7 +26,7 @@ type Marker = u32;
 
 pub fn check_vram_and_block(max_ram: usize, file: &str) {
     if let Some(usage) = memory_stats() {
-        let mut gb_usage_curr = usage.virtual_mem as f64 / 1_000_000_000 as f64;
+        let mut gb_usage_curr = usage.virtual_mem as f64 / 1_000_000_000_f64;
         if (max_ram as f64) < gb_usage_curr {
             log::debug!(
                 "Max memory reached. Blocking sketch for {}. Curr memory {}, max mem {}",
@@ -39,7 +39,7 @@ pub fn check_vram_and_block(max_ram: usize, file: &str) {
             let five_second = Duration::from_secs(1);
             thread::sleep(five_second);
             if let Some(usage) = memory_stats() {
-                gb_usage_curr = usage.virtual_mem as f64 / 1_000_000_000 as f64;
+                gb_usage_curr = usage.virtual_mem as f64 / 1_000_000_000_f64;
                 if (max_ram as f64) >= gb_usage_curr {
                     log::debug!("Sketching for {} freed", file);
                 }
@@ -93,31 +93,19 @@ pub fn extract_markers_positions(
 }
 
 pub fn is_fastq(file: &str) -> bool {
-    if file.ends_with(".fq")
+    file.ends_with(".fq")
         || file.ends_with(".fnq")
         || file.ends_with(".fastq")
         || file.ends_with(".fq.gz")
-        || file.ends_with(".fnq.gz")
-        || file.ends_with(".fastq.gz")
-    {
-        return true;
-    } else {
-        return false;
-    }
+        || file.ends_with(".fnq.gz") || file.ends_with(".fastq.gz")
 }
 
 pub fn is_fasta(file: &str) -> bool {
-    if file.ends_with(".fa")
+    file.ends_with(".fa")
         || file.ends_with(".fna")
         || file.ends_with(".fasta")
         || file.ends_with(".fa.gz")
-        || file.ends_with(".fna.gz")
-        || file.ends_with(".fasta.gz")
-    {
-        return true;
-    } else {
-        return false;
-    }
+        || file.ends_with(".fna.gz") || file.ends_with(".fasta.gz")
 }
 
 fn check_args_valid(args: &SketchArgs) {
@@ -259,7 +247,7 @@ fn parse_line_file(file_name: &str, vec: &mut Vec<String>) {
 
 fn parse_sample_names(args: &SketchArgs) -> Option<Vec<String>> {
     if args.list_sample_names.is_none() && args.sample_names.is_none() {
-        return None;
+        None
     } else {
         let mut sample_names = vec![];
         if let Some(file) = &args.list_sample_names {
@@ -269,7 +257,7 @@ fn parse_sample_names(args: &SketchArgs) -> Option<Vec<String>> {
         if let Some(vec) = &args.sample_names {
             sample_names.extend(vec.clone());
         }
-        return Some(sample_names);
+        Some(sample_names)
     }
 }
 
@@ -344,7 +332,7 @@ pub fn sketch(args: SketchArgs) {
                 }
 
                 let read_file_path = Path::new(&sketch_name).file_name().unwrap();
-                let file_path = pref.join(&read_file_path);
+                let file_path = pref.join(read_file_path);
 
                 let file_path_str = format!(
                     "{}.paired{}",
@@ -354,7 +342,7 @@ pub fn sketch(args: SketchArgs) {
 
                 let mut read_sk_file = BufWriter::new(
                     File::create(&file_path_str)
-                        .expect(&format!("{} path not valid; exiting ", file_path_str)),
+                        .unwrap_or_else(|_| panic!("{} path not valid; exiting ", file_path_str)),
                 );
 
                 bincode::serialize_into(&mut read_sk_file, &read_sketch).unwrap();
@@ -381,8 +369,8 @@ pub fn sketch(args: SketchArgs) {
             sample_name = Some(name[i + first_pairs.len()].clone());
         }
 
-        let read_sketch_opt;
-        read_sketch_opt = sketch_sequences_needle(
+        
+        let read_sketch_opt = sketch_sequences_needle(
             read_file,
             args.c,
             args.k,
@@ -399,13 +387,13 @@ pub fn sketch(args: SketchArgs) {
                 sketch_name = &read_sketch.file_name;
             }
             let read_file_path = Path::new(&sketch_name).file_name().unwrap();
-            let file_path = pref.join(&read_file_path);
+            let file_path = pref.join(read_file_path);
 
             let file_path_str = format!("{}{}", file_path.to_str().unwrap(), SAMPLE_FILE_SUFFIX);
 
             let mut read_sk_file = BufWriter::new(
                 File::create(&file_path_str)
-                    .expect(&format!("{} path not valid; exiting.", file_path_str)),
+                    .unwrap_or_else(|_| panic!("{} path not valid; exiting.", file_path_str)),
             );
 
             bincode::serialize_into(&mut read_sk_file, &read_sketch).unwrap();
@@ -456,7 +444,7 @@ pub fn sketch(args: SketchArgs) {
             }
             let mut c = counter.lock().unwrap();
             *c += 1;
-            if *c % 100 == 0 && *c != 0 {
+            if (*c).is_multiple_of(100) && *c != 0 {
                 info!("{} genomes processed.", *c);
             }
         });
@@ -468,7 +456,7 @@ pub fn sketch(args: SketchArgs) {
             );
         } else {
             let mut genome_sk_file = BufWriter::new(
-                File::create(&file_path_str).expect(&format!("{} not valid ", file_path_str)),
+                File::create(&file_path_str).unwrap_or_else(|_| panic!("{} not valid ", file_path_str)),
             );
             info!("Wrote all genome sketches to {}", file_path_str);
             bincode::serialize_into(&mut genome_sk_file, &all_genome_sketches).unwrap();
@@ -485,10 +473,10 @@ pub fn sketch_genome_individual(
     min_spacing: usize,
     pseudotax: bool,
 ) -> Vec<GenomeSketch> {
-    let reader = parse_fastx_file(&ref_file);
-    if !reader.is_ok() {
+    let reader = parse_fastx_file(ref_file);
+    if reader.is_err() {
         warn!("{} is not a valid fasta/fastq file; skipping.", ref_file);
-        return vec![];
+        vec![]
     } else {
         let mut reader = reader.unwrap();
         let mut return_vec = vec![];
@@ -500,7 +488,7 @@ pub fn sketch_genome_individual(
             if record.is_ok() {
                 let mut pseudotax_track_kmers = vec![];
                 let mut kmer_vec = vec![];
-                let record = record.expect(&format!("Invalid record for file {} ", ref_file));
+                let record = record.unwrap_or_else(|_| panic!("Invalid record for file {} ", ref_file));
                 let contig_name = String::from_utf8_lossy(record.id()).to_string();
                 let contig_name_notab = contig_name.replace('\t', " ");
                 return_genome_sketch.first_contig_name = contig_name_notab.to_owned();
@@ -544,7 +532,7 @@ pub fn sketch_genome_individual(
                 return vec![];
             }
         }
-        return return_vec;
+        return_vec
     }
 }
 
@@ -555,12 +543,12 @@ pub fn sketch_genome(
     min_spacing: usize,
     pseudotax: bool,
 ) -> Option<GenomeSketch> {
-    let reader = parse_fastx_file(&ref_file);
+    let reader = parse_fastx_file(ref_file);
     let mut vec = vec![];
     let mut pseudotax_track_kmers = vec![];
-    if !reader.is_ok() {
+    if reader.is_err() {
         warn!("{} is not a valid fasta/fastq file; skipping.", ref_file);
-        return None;
+        None
     } else {
         let mut reader = reader.unwrap();
         let mut first = true;
@@ -571,7 +559,7 @@ pub fn sketch_genome(
         let mut contig_number = 0;
         while let Some(record) = reader.next() {
             if record.is_ok() {
-                let record = record.expect(&format!("Invalid record for file {} ", ref_file));
+                let record = record.unwrap_or_else(|_| panic!("Invalid record for file {} ", ref_file));
                 if first {
                     let contig_name = String::from_utf8_lossy(record.id()).to_string();
                     let contig_name_notab = contig_name.replace('\t', " ");
@@ -619,7 +607,7 @@ pub fn sketch_genome(
         if pseudotax {
             return_genome_sketch.pseudotax_tracked_nonused_kmers = Some(pseudotax_track_kmers);
         }
-        return Some(return_genome_sketch);
+        Some(return_genome_sketch)
     }
 }
 
@@ -627,7 +615,7 @@ pub fn sketch_genome(
 fn pair_kmer_single(s1: &[u8]) -> Option<([Marker; 2], [Marker; 2])> {
     let k = std::mem::size_of::<Marker>() * 4;
     if s1.len() < 4 * k + 2 {
-        return None;
+        None
     } else {
         let mut kmer_f = 0;
         let mut kmer_g = 0;
@@ -653,7 +641,7 @@ fn pair_kmer_single(s1: &[u8]) -> Option<([Marker; 2], [Marker; 2])> {
             kmer_t <<= 2;
             kmer_t |= nuc_4;
         }
-        return Some(([kmer_f, kmer_r], [kmer_g, kmer_t]));
+        Some(([kmer_f, kmer_r], [kmer_g, kmer_t]))
     }
 }
 
@@ -661,7 +649,7 @@ fn pair_kmer_single(s1: &[u8]) -> Option<([Marker; 2], [Marker; 2])> {
 fn pair_kmer(s1: &[u8], s2: &[u8]) -> Option<([Marker; 2], [Marker; 2])> {
     let k = std::mem::size_of::<Marker>() * 4;
     if s1.len() < 2 * k + 1 || s2.len() < 2 * k + 1 {
-        return None;
+        None
     } else {
         let mut kmer_f = 0;
         let mut kmer_g = 0;
@@ -685,7 +673,7 @@ fn pair_kmer(s1: &[u8], s2: &[u8]) -> Option<([Marker; 2], [Marker; 2])> {
             kmer_t <<= 2;
             kmer_t |= nuc_4;
         }
-        return Some(([kmer_f, kmer_r], [kmer_g, kmer_t]));
+        Some(([kmer_f, kmer_r], [kmer_g, kmer_t]))
     }
 }
 
@@ -779,8 +767,8 @@ pub fn sketch_pair_sequences(
     no_dedup: bool,
     dedup_fpr: f64,
 ) -> Option<SequencesSketch> {
-    let r1o = parse_fastx_file(&read_file1);
-    let r2o = parse_fastx_file(&read_file2);
+    let r1o = parse_fastx_file(read_file1);
+    let r2o = parse_fastx_file(read_file2);
     let mut read_sketch = SequencesSketch::new(read_file1.to_string(), c, k, true, sample_name, 0.);
     if r1o.is_err() || r2o.is_err() {
         log::error!("Paired end reading failed for '{}' and '{}'. Make sure the files are present or the sequences are valid.", read_file1, read_file2);
@@ -885,7 +873,9 @@ pub fn sketch_pair_sequences(
             break;
         }
     }
-    let percent = (num_dup_removed as f64)/((read_sketch.kmer_counts.values().sum::<u32>() as f64) + num_dup_removed as f64) * 100.;
+    let percent = (num_dup_removed as f64)
+        / ((read_sketch.kmer_counts.values().sum::<u32>() as f64) + num_dup_removed as f64)
+        * 100.;
     log::debug!(
         "Number of sketched k-mers removed due to read duplication for {}: {}. Percentage: {:.2}%",
         read_sketch.file_name,
@@ -893,7 +883,7 @@ pub fn sketch_pair_sequences(
         percent,
     );
     read_sketch.mean_read_length = mean_read_length;
-    return Some(read_sketch);
+    Some(read_sketch)
 }
 
 pub fn sketch_sequences_needle(
@@ -905,21 +895,21 @@ pub fn sketch_sequences_needle(
 ) -> Option<SequencesSketch> {
     let mut kmer_map = HashMap::default();
     let ref_file = &read_file;
-    let reader = parse_fastx_file(&ref_file);
+    let reader = parse_fastx_file(ref_file);
     let mut mean_read_length = 0.;
     let mut counter = 0.;
     let mut kmer_to_pair_table = FxHashSet::default();
     let mut num_dup_removed = 0;
 
-    if !reader.is_ok() {
+    if reader.is_err() {
         warn!("{} is not a valid fasta/fastq file; skipping.", ref_file);
-        return None
+        return None;
     } else {
         let mut reader = reader.unwrap();
         while let Some(record) = reader.next() {
             if record.is_ok() {
                 let mut vec = vec![];
-                let record = record.expect(&format!("Invalid record for file {} ", ref_file));
+                let record = record.unwrap_or_else(|_| panic!("Invalid record for file {} ", ref_file));
                 let seq = record.seq();
                 let kmer_pair;
                 if seq.len() > 400 {
@@ -949,13 +939,13 @@ pub fn sketch_sequences_needle(
         }
     }
 
-    return Some(SequencesSketch {
+    Some(SequencesSketch {
         kmer_counts: kmer_map,
         file_name: read_file.to_string(),
         c,
         k,
         paired: false,
-        sample_name: sample_name,
+        sample_name,
         mean_read_length,
-    });
+    })
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,26 +25,24 @@
 //SOFTWARE.
 //******************************
 
-
 use std::collections::HashMap;
 
 // bytecheck can be used to validate your data if you want
-use std::hash::{BuildHasherDefault, Hasher};
-use std::collections::HashSet;
-use smallvec::SmallVec;
-use serde::{Deserialize, Serialize, Serializer, Deserializer, de::Visitor};
 use fxhash::FxHashMap;
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use smallvec::SmallVec;
+use std::collections::HashSet;
+use std::hash::{BuildHasherDefault, Hasher};
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Default)]
 pub enum AdjustStatus {
     Lambda(f64),
+    #[default]
     Low,
     High,
 }
 
-impl Default for AdjustStatus {
-    fn default() -> Self {AdjustStatus::Low }
-}
 
 pub type Kmer = u64;
 pub const BYTE_TO_SEQ: [u8; 256] = [
@@ -60,7 +58,7 @@ pub const BYTE_TO_SEQ: [u8; 256] = [
 
 #[inline]
 pub fn mm_hash(bytes: &[u8]) -> usize {
-    let mut key = usize::from_ne_bytes(bytes.try_into().unwrap()) as usize;
+    let mut key = usize::from_ne_bytes(bytes.try_into().unwrap());
     key = (!key).wrapping_add(key << 21); // key = (key << 21) - key - 1;
     key = key ^ key >> 24;
     key = (key.wrapping_add(key << 3)).wrapping_add(key << 8); // key * 265
@@ -68,7 +66,7 @@ pub fn mm_hash(bytes: &[u8]) -> usize {
     key = (key.wrapping_add(key << 2)).wrapping_add(key << 4); // key * 21
     key = key ^ key >> 28;
     key = key.wrapping_add(key << 31);
-    return key;
+    key
 }
 
 pub struct MMHasher {
@@ -99,14 +97,14 @@ pub type MMHashMap<K, V> = HashMap<K, V, MMBuildHasher>;
 pub type MMHashSet<K> = HashSet<K, MMBuildHasher>;
 
 /// `serde` helpers to improve serialization of the `FxHashMap` storing k-mer counts.
-/// 
+///
 /// Encoding the `FxHashMap` as a sequence instead of a map speeds up serialize
 /// and deserialize by a magnitude.
 mod kmer_counts {
     use super::*;
 
     struct FxHashMapVisitor;
-    
+
     impl<'a> Visitor<'a> for FxHashMapVisitor {
         type Value = FxHashMap<Kmer, u32>;
 
@@ -115,8 +113,8 @@ mod kmer_counts {
         }
 
         fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::SeqAccess<'a>
+        where
+            A: serde::de::SeqAccess<'a>,
         {
             let mut counts = match seq.size_hint() {
                 Some(size) => FxHashMap::with_capacity_and_hasher(size, Default::default()),
@@ -130,20 +128,25 @@ mod kmer_counts {
     }
 
     pub fn serialize<S>(
-        kmer_counts: &FxHashMap<Kmer, u32>, 
-        serializer: S
-    ) -> Result<S::Ok, S::Error> 
-    where S: Serializer {
-        serializer.collect_seq(kmer_counts.into_iter())
+        kmer_counts: &FxHashMap<Kmer, u32>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_seq(kmer_counts)
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<FxHashMap<Kmer, u32>, D::Error> where D: Deserializer<'de> {
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<FxHashMap<Kmer, u32>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         deserializer.deserialize_seq(FxHashMapVisitor)
     }
 }
 
 #[derive(Default, Deserialize, Serialize, Debug, PartialEq)]
-pub struct SequencesSketch{
+pub struct SequencesSketch {
     #[serde(with = "kmer_counts")]
     pub kmer_counts: FxHashMap<Kmer, u32>,
     pub c: usize,
@@ -154,14 +157,29 @@ pub struct SequencesSketch{
     pub mean_read_length: f64,
 }
 
-impl SequencesSketch{
-    pub fn new(file_name: String, c: usize, k: usize, paired: bool, sample_name: Option<String>, mean_read_length: f64) -> SequencesSketch{
-        return SequencesSketch{kmer_counts : HashMap::default(), file_name, c, k, paired, sample_name, mean_read_length}
+impl SequencesSketch {
+    pub fn new(
+        file_name: String,
+        c: usize,
+        k: usize,
+        paired: bool,
+        sample_name: Option<String>,
+        mean_read_length: f64,
+    ) -> SequencesSketch {
+        SequencesSketch {
+            kmer_counts: HashMap::default(),
+            file_name,
+            c,
+            k,
+            paired,
+            sample_name,
+            mean_read_length,
+        }
     }
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Hash, PartialOrd, Eq, Ord, Default, Clone)]
-pub struct GenomeSketch{
+pub struct GenomeSketch {
     pub genome_kmers: Vec<Kmer>,
     pub pseudotax_tracked_nonused_kmers: Option<Vec<Kmer>>,
     pub file_name: String,
@@ -172,10 +190,9 @@ pub struct GenomeSketch{
     pub min_spacing: usize,
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
-#[derive(Default, Clone)]
-pub struct MultGenomeSketch{
-    pub genome_kmer_index: Vec<(Kmer,SmallVec<[u32;1]>)>,
+#[derive(Deserialize, Serialize, Debug, PartialEq, Default, Clone)]
+pub struct MultGenomeSketch {
+    pub genome_kmer_index: Vec<(Kmer, SmallVec<[u32; 1]>)>,
     pub file_names: Vec<String>,
     pub contig_names: Vec<String>,
     pub c: usize,
@@ -183,7 +200,7 @@ pub struct MultGenomeSketch{
 }
 
 #[derive(Debug, PartialEq)]
-pub struct AniResult<'a>{
+pub struct AniResult<'a> {
     pub naive_ani: f64,
     pub final_est_ani: f64,
     pub final_est_cov: f64,
@@ -192,13 +209,12 @@ pub struct AniResult<'a>{
     pub contig_name: &'a str,
     pub mean_cov: f64,
     pub median_cov: f64,
-    pub containment_index: (usize,usize),
+    pub containment_index: (usize, usize),
     pub lambda: AdjustStatus,
-    pub ani_ci: (Option<f64>,Option<f64>),
-    pub lambda_ci: (Option<f64>,Option<f64>),
+    pub ani_ci: (Option<f64>, Option<f64>),
+    pub lambda_ci: (Option<f64>, Option<f64>),
     pub genome_sketch: &'a GenomeSketch,
     pub rel_abund: Option<f64>,
     pub seq_abund: Option<f64>,
     pub kmers_lost: Option<usize>,
-
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,11 +1,11 @@
 use assert_cmd::prelude::*; // Add methods on commands
-use std::str;
+use serial_test::serial;
 use std::fs;
 use std::path::Path;
-use serial_test::serial;
-use std::process::Command; // Run programs
+use std::process::Command;
+use std::str; // Run programs
 
-fn fresh(){
+fn fresh() {
     Command::new("rm")
         .arg("-r")
         .args(["./tests/results/test_sketch_dir"])
@@ -15,7 +15,7 @@ fn fresh(){
 #[serial]
 #[test]
 fn test_sketch_commands() {
-   let mut cmd = Command::cargo_bin("sylph").unwrap();
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
         .arg("sketch")
         .arg("test_files/e.coli-EC590.fasta.gz")
@@ -44,7 +44,6 @@ fn test_sketch_commands() {
         .assert();
     assert.success().code(0);
 
-
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
         .arg("profile")
@@ -64,7 +63,7 @@ fn test_sketch_commands() {
         .assert();
     assert.success().code(0);
 
-    let mut cmd= Command::cargo_bin("sylph").unwrap();
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
         .arg("sketch")
         .arg("-1")
@@ -75,10 +74,13 @@ fn test_sketch_commands() {
         .arg("./tests/results/test_sketch_dir")
         .assert();
     assert.success().code(0);
-    assert!(Path::new("./tests/results/test_sketch_dir/t1.fq.paired.sylsp").exists(), "Output file was not created");
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/t1.fq.paired.sylsp").exists(),
+        "Output file was not created"
+    );
     fresh();
 
-    let mut cmd= Command::cargo_bin("sylph").unwrap();
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
         .arg("sketch")
         .arg("--l1")
@@ -89,10 +91,13 @@ fn test_sketch_commands() {
         .arg("./tests/results/test_sketch_dir")
         .assert();
     assert.success().code(0);
-    assert!(Path::new("./tests/results/test_sketch_dir/t1.fq.paired.sylsp").exists(), "Output file was not created");
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/t1.fq.paired.sylsp").exists(),
+        "Output file was not created"
+    );
 
     fresh();
-    let mut cmd= Command::cargo_bin("sylph").unwrap();
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
         .arg("sketch")
         .arg("-g")
@@ -105,13 +110,19 @@ fn test_sketch_commands() {
         .arg("./tests/results/test_sketch_dir/testdb")
         .assert();
     assert.success().code(0);
-    assert!(Path::new("./tests/results/test_sketch_dir/t2.fq.sylsp").exists(), "Output file was not created");
-    assert!(Path::new("./tests/results/test_sketch_dir/testdb.syldb").exists(), "Output file was not created");
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/t2.fq.sylsp").exists(),
+        "Output file was not created"
+    );
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/testdb.syldb").exists(),
+        "Output file was not created"
+    );
 }
 
 #[serial]
 #[test]
-fn test_profile_vs_query(){
+fn test_profile_vs_query() {
     fresh();
 
     let mut output = Command::cargo_bin("sylph").unwrap();
@@ -136,13 +147,13 @@ fn test_profile_vs_query(){
         .expect("Output failed");
     let stdout = str::from_utf8(&output.stdout).expect("Output was not valid UTF-8");
     dbg!(stdout.matches('\n').count());
-    println!("{}",stdout);
+    println!("{}", stdout);
     assert!(stdout.matches('\n').count() == 4);
 }
 
 #[serial]
 #[test]
-fn test_sketch_list(){
+fn test_sketch_list() {
     fresh();
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
@@ -156,9 +167,18 @@ fn test_sketch_list(){
         .arg("./tests/results/test_sketch_dir")
         .assert();
     assert.success().code(0);
-    assert!(Path::new("./tests/results/test_sketch_dir/e.coli-EC590.fasta.gz.sylsp").exists(), "Output file was not created");
-    assert!(Path::new("./tests/results/test_sketch_dir/o157_reads.fastq.gz.sylsp").exists(), "Output file was not created");
-    assert!(!Path::new("./tests/results/test_sketch_dir/db.syldb").exists(), "Output file was created");
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/e.coli-EC590.fasta.gz.sylsp").exists(),
+        "Output file was not created"
+    );
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/o157_reads.fastq.gz.sylsp").exists(),
+        "Output file was not created"
+    );
+    assert!(
+        !Path::new("./tests/results/test_sketch_dir/db.syldb").exists(),
+        "Output file was created"
+    );
     fresh();
 
     let mut cmd = Command::cargo_bin("sylph").unwrap();
@@ -173,9 +193,18 @@ fn test_sketch_list(){
         .arg("./tests/results/test_sketch_dir")
         .assert();
     assert.success().code(0);
-    assert!(!Path::new("./tests/results/test_sketch_dir/e.coli-EC590.fasta.gz.sylsp").exists(), "Output file was created");
-    assert!(!Path::new("./tests/results/test_sketch_dir/o157_reads.fastq.gz.sylsp").exists(), "Output file was created");
-    assert!(Path::new("./tests/results/test_sketch_dir/db.syldb").exists(), "Output file was not created");
+    assert!(
+        !Path::new("./tests/results/test_sketch_dir/e.coli-EC590.fasta.gz.sylsp").exists(),
+        "Output file was created"
+    );
+    assert!(
+        !Path::new("./tests/results/test_sketch_dir/o157_reads.fastq.gz.sylsp").exists(),
+        "Output file was created"
+    );
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/db.syldb").exists(),
+        "Output file was not created"
+    );
     fresh();
 
     let mut cmd = Command::cargo_bin("sylph").unwrap();
@@ -187,7 +216,10 @@ fn test_sketch_list(){
         .arg("./tests/results/test_sketch_dir/db")
         .assert();
     assert.success().code(0);
-    assert!(Path::new("./tests/results/test_sketch_dir/db.syldb").exists(), "Output file was not created");
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/db.syldb").exists(),
+        "Output file was not created"
+    );
     fresh();
 
     let mut cmd = Command::cargo_bin("sylph").unwrap();
@@ -201,15 +233,23 @@ fn test_sketch_list(){
         .arg("./tests/results/test_sketch_dir")
         .assert();
     assert.success().code(0);
-    assert!(!Path::new("./tests/results/test_sketch_dir/db.syldb").exists(), "Output file was not created");
-    assert!(Path::new("./tests/results/test_sketch_dir/e.coli-EC590.fasta.gz.sylsp").exists(), "Output file was not created");
-    assert!(Path::new("./tests/results/test_sketch_dir/o157_reads.fastq.gz.sylsp").exists(), "Output file was not created");
+    assert!(
+        !Path::new("./tests/results/test_sketch_dir/db.syldb").exists(),
+        "Output file was not created"
+    );
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/e.coli-EC590.fasta.gz.sylsp").exists(),
+        "Output file was not created"
+    );
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/o157_reads.fastq.gz.sylsp").exists(),
+        "Output file was not created"
+    );
     fresh();
-
 }
 #[serial]
 #[test]
-fn test_profile_disabling(){
+fn test_profile_disabling() {
     fresh();
 
     let mut cmd = Command::cargo_bin("sylph").unwrap();
@@ -245,7 +285,7 @@ fn test_profile_disabling(){
 }
 #[serial]
 #[test]
-fn test_sketch_fasta_fastq_concord(){
+fn test_sketch_fasta_fastq_concord() {
     fresh();
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
@@ -295,7 +335,7 @@ fn test_sketch_fasta_fastq_concord(){
 }
 #[serial]
 #[test]
-fn test_sample_names(){
+fn test_sample_names() {
     fresh();
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
@@ -310,7 +350,10 @@ fn test_sample_names(){
         .arg("./test_files/single_sample.txt")
         .assert();
     assert.success().code(0);
-    assert!(Path::new("./tests/results/test_sketch_dir/SAMPLE_TEST.paired.sylsp").exists(), "Output file was not created");
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/SAMPLE_TEST.paired.sylsp").exists(),
+        "Output file was not created"
+    );
     fresh();
 
     let mut cmd = Command::cargo_bin("sylph").unwrap();
@@ -324,15 +367,22 @@ fn test_sample_names(){
         .arg("./test_files/sample_list.txt")
         .assert();
     assert.success().code(0);
-    assert!(Path::new("./tests/results/test_sketch_dir/S1.sylsp").exists(), "Output file was not created");
-    assert!(Path::new("./tests/results/test_sketch_dir/S2.sylsp").exists(), "Output file was not created");
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/S1.sylsp").exists(),
+        "Output file was not created"
+    );
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/S2.sylsp").exists(),
+        "Output file was not created"
+    );
 
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     let output = cmd
         .arg("profile")
         .arg("./tests/results/test_sketch_dir/S2.sylsp")
         .arg("./test_files/e.coli-EC590.fasta.gz")
-        .output().unwrap();
+        .output()
+        .unwrap();
     let stdout = str::from_utf8(&output.stdout).expect("Output was not valid UTF-8");
     dbg!(&stdout);
     assert!(stdout.contains("S2"));
@@ -351,7 +401,10 @@ fn test_sample_names(){
         .arg("SAMPLE_TEST_S")
         .assert();
     assert.success().code(0);
-    assert!(Path::new("./tests/results/test_sketch_dir/SAMPLE_TEST_S.paired.sylsp").exists(), "Output file was not created, -S");
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/SAMPLE_TEST_S.paired.sylsp").exists(),
+        "Output file was not created, -S"
+    );
 
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
@@ -369,13 +422,16 @@ fn test_sample_names(){
         .arg("SAMPLE_TEST_S1")
         .assert();
     assert.success().code(0);
-    assert!(Path::new("./tests/results/test_sketch_dir/SAMPLE_TEST_S1.paired.sylsp").exists(), "Output file was not created, -S");
+    assert!(
+        Path::new("./tests/results/test_sketch_dir/SAMPLE_TEST_S1.paired.sylsp").exists(),
+        "Output file was not created, -S"
+    );
 
     fresh();
 }
 #[serial]
 #[test]
-fn test_fpr(){
+fn test_fpr() {
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
         .arg("sketch")
@@ -418,11 +474,10 @@ fn test_fpr(){
         .assert();
     assert.failure().code(1);
     fresh();
-
 }
 #[serial]
 #[test]
-fn test_raw_inputs_profile_simple(){
+fn test_raw_inputs_profile_simple() {
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
         .arg("profile")
@@ -458,12 +513,11 @@ fn test_raw_inputs_profile_simple(){
         .assert();
     assert.success().code(0);
     fresh();
-    
 }
 
 #[serial]
 #[test]
-fn test_estimate_read_counts(){
+fn test_estimate_read_counts() {
     let mut cmd = Command::cargo_bin("sylph").unwrap();
     let output = cmd
         .arg("profile")
@@ -480,7 +534,7 @@ fn test_estimate_read_counts(){
     dbg!(stdout_1);
     lines.next();
     let output = lines.next().unwrap();
-    let split : Vec<&str> = output.split('\t').collect();
+    let split: Vec<&str> = output.split('\t').collect();
     assert!(split[3].parse::<f64>().unwrap() > 1000.0);
 
     fresh();
@@ -500,17 +554,15 @@ fn test_estimate_read_counts(){
     dbg!(stdout_1);
     lines.next();
     let output = lines.next().unwrap();
-    let split : Vec<&str> = output.split('\t').collect();
+    let split: Vec<&str> = output.split('\t').collect();
     assert!(split[3].parse::<f64>().unwrap() < 101.00);
 
     fresh();
-
 }
 
 #[serial]
 #[test]
-fn test_raw_inputs_profile_with_sketch(){
-    
+fn test_raw_inputs_profile_with_sketch() {
     let mut output = Command::cargo_bin("sylph").unwrap();
     let output = output
         .arg("profile")
@@ -549,8 +601,8 @@ fn test_raw_inputs_profile_with_sketch(){
 
 #[serial]
 #[test]
-fn test_inspect(){
-   let mut cmd = Command::cargo_bin("sylph").unwrap();
+fn test_inspect() {
+    let mut cmd = Command::cargo_bin("sylph").unwrap();
     let assert = cmd
         .arg("sketch")
         .arg("test_files/e.coli-EC590.fasta.gz")
@@ -593,5 +645,4 @@ fn test_inspect(){
     let stdout = str::from_utf8(&output.stdout).expect("Output was not valid UTF-8");
     assert!(stdout.contains("e.coli-EC590.fasta.gz"));
     assert!(stdout.contains("e.coli-K12.fasta.gz"));
-
 }

--- a/tests/unit_test.rs
+++ b/tests/unit_test.rs
@@ -1,8 +1,7 @@
 use assert_cmd::prelude::*; // Add methods on commands
 use sylph::seeding;
 
-fn test_hash(){
-
+fn test_hash() {
     let key = 19238239812933123;
     println!("{}", format!("{key:b}"));
     let h = seeding::mm_hash64(key);
@@ -11,18 +10,17 @@ fn test_hash(){
     println!("{}", format!("{rev:b}"));
     assert!(rev == key);
 
-    if is_x86_feature_detected!("avx2"){
-        unsafe{
+    if is_x86_feature_detected!("avx2") {
+        unsafe {
             let key = key as i64;
             println!("{}", format!("{key:b}"));
             use std::arch::x86_64::*;
             use sylph::avx2_seeding::*;
             let mut rolling_kmer_f_marker = _mm256_set_epi64x(0, 0, 0, key);
-                let hash_256 = mm_hash256(rolling_kmer_f_marker);
-                let v1 = _mm256_extract_epi64(hash_256, 0);
-                println!("{}", format!("{v1:b}"));
-                assert!(v1 == h as i64);
+            let hash_256 = mm_hash256(rolling_kmer_f_marker);
+            let v1 = _mm256_extract_epi64(hash_256, 0);
+            println!("{}", format!("{v1:b}"));
+            assert!(v1 == h as i64);
         }
-
     }
 }


### PR DESCRIPTION
Just formatting stuff. All automated - there's still 64 clippy warnings that ask for manual attention.