### PR TITLE
Pin rand to 0.9, seed cuckoo filter RNG for reproducible sketching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,7 +582,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "simba",
  "typenum",
@@ -817,14 +829,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -834,7 +862,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -843,7 +881,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -853,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -943,11 +990,11 @@ dependencies = [
 
 [[package]]
 name = "scalable_cuckoo_filter"
-version = "0.2.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b1a585939dc043527d08ae2520e374803780fbfab3bfc5ee3d4ecf163de993"
+checksum = "16b972322ef7f2b9198e52ce686b5809906817eee472f687db9b4832b476d6f5"
 dependencies = [
- "rand",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -1096,7 +1143,7 @@ dependencies = [
  "lazy_static",
  "nalgebra",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1120,7 +1167,7 @@ dependencies = [
  "nalgebra",
  "needletail",
  "predicates 1.0.8",
- "rand",
+ "rand 0.9.4",
  "rayon",
  "regex",
  "scalable_cuckoo_filter",
@@ -1267,6 +1314,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wide"
@@ -1456,6 +1512,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,13 @@ clap = { version = "3", features = ["derive"] }
 flate2 = { version = "1.0.17", features = ["zlib-ng"], default-features = false }
 statrs="0.16"
 nalgebra="0"
-rand = "0"
+# Pinned to 0.9 to match scalable_cuckoo_filter 0.5's Rng trait, so the dedup
+# filters can be given a fixed-seed StdRng for reproducible sketching.
+rand = "0.9"
 regex = "1"
 fastrand = "2"
 memory-stats = "1"
-scalable_cuckoo_filter = "0.2"
+scalable_cuckoo_filter = "0.5"
 serde_yaml = "0.9"
 
 [target.'cfg(target_env = "musl")'.dependencies]

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -1,6 +1,12 @@
 use crate::cmdline::*;
+use rand::SeedableRng;
 use scalable_cuckoo_filter::ScalableCuckooFilter;
 use scalable_cuckoo_filter::ScalableCuckooFilterBuilder;
+
+/// Fixed seed for the dedup cuckoo filters' eviction RNG. The default builder seeds
+/// from entropy, which makes a handful of dedup decisions (and thus a few k-mer counts)
+/// vary run-to-run; a constant seed makes read sketches reproducible.
+const DEDUP_RNG_SEED: u64 = 0;
 
 use fxhash::FxHashMap;
 use fxhash::FxHashSet;
@@ -732,10 +738,10 @@ fn dup_removal_lsh_full_exact(
     *c += 1;
 }
 
-fn dup_removal_lsh_full(
+fn dup_removal_lsh_full<R: rand::Rng>(
     kmer_counts: &mut FxHashMap<Kmer, u32>,
     //kmer_to_pair_set: &mut FxHashSet<(u64,[Marker;2])>,
-    kmer_to_pair_set: &mut ScalableCuckooFilter<(u64, [Marker; 2]), FxHasher>,
+    kmer_to_pair_set: &mut ScalableCuckooFilter<(u64, [Marker; 2]), FxHasher, R>,
     //kmer_to_pair_set: &mut GrowableBloom,
     km: &u64,
     kmer_pair: Option<([Marker; 2], [Marker; 2])>,
@@ -803,6 +809,9 @@ pub fn sketch_pair_sequences(
         .initial_capacity(1_000_000_0)
         .false_positive_probability(fpr)
         .hasher(FxHasher::default())
+        // Fixed-seed RNG so the cuckoo filter's random eviction is deterministic,
+        // making paired/interleaved read sketches byte-reproducible run-to-run.
+        .rng(rand::rngs::StdRng::seed_from_u64(DEDUP_RNG_SEED))
         .finish();
 
     let mut mean_read_length: f64 = 0.;


### PR DESCRIPTION
Wanted to make Weebill exactly reproduce sylph sketches. But sylph itself was not reproducible because the cuckoo filter wasn't seeded, which pops up with the dedup. This branch fixes that (and now weebill sketches match too).